### PR TITLE
<Feat> - 인터뷰에 대한 종합 결과를 조회하는 기능 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -33,3 +33,11 @@ include::{snippetsDir}/interview-proceedInterview/path-parameters.adoc[]
 include::{snippetsDir}/interview-proceedInterview/http-response.adoc[]
 include::{snippetsDir}/interview-proceedInterview/response-fields.adoc[]
 include::{snippetsDir}/interview-proceedInterview/curl-request.adoc[]
+
+=== 인터뷰 최종 결과 조회
+
+include::{snippetsDir}/interview-findTotalFeedbacks/http-request.adoc[]
+include::{snippetsDir}/interview-findTotalFeedbacks/path-parameters.adoc[]
+include::{snippetsDir}/interview-findTotalFeedbacks/http-response.adoc[]
+include::{snippetsDir}/interview-findTotalFeedbacks/response-fields.adoc[]
+include::{snippetsDir}/interview-findTotalFeedbacks/curl-request.adoc[]

--- a/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
+++ b/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
@@ -5,8 +5,10 @@ import com.samhap.kokomen.interview.service.InterviewService;
 import com.samhap.kokomen.interview.service.dto.AnswerRequest;
 import com.samhap.kokomen.interview.service.dto.InterviewRequest;
 import com.samhap.kokomen.interview.service.dto.InterviewResponse;
+import com.samhap.kokomen.interview.service.dto.InterviewTotalResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,8 +37,15 @@ public class InterviewController {
             @PathVariable Long questionId,
             @RequestBody AnswerRequest answerRequest
     ) {
-        return interviewService.proceedInterview(interviewId, questionId, answerRequest, null)
+        return interviewService.proceedInterview(interviewId, questionId, answerRequest, new MemberAuth(1L))
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @GetMapping("/{interviewId}/result")
+    public ResponseEntity<InterviewTotalResponse> findTotalFeedbacks(
+            @PathVariable Long interviewId
+    ) {
+        return ResponseEntity.ok(interviewService.findTotalFeedbacks(interviewId, new MemberAuth(1L)));
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/domain/AnswerRank.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/AnswerRank.java
@@ -1,5 +1,8 @@
 package com.samhap.kokomen.interview.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum AnswerRank {
     A(20),
     B(10),
@@ -13,5 +16,4 @@ public enum AnswerRank {
     AnswerRank(int score) {
         this.score = score;
     }
-
 }

--- a/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
@@ -28,7 +28,14 @@ public class Interview extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Column(name = "total_feedback", length = 2_000)
+    private String totalFeedback;
+
     public Interview(Member member) {
         this.member = member;
+    }
+
+    public void feedbackTotal(String totalFeedback) {
+        this.totalFeedback = totalFeedback;
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
@@ -31,11 +31,15 @@ public class Interview extends BaseEntity {
     @Column(name = "total_feedback", length = 2_000)
     private String totalFeedback;
 
+    @Column(name = "total_score")
+    private Integer totalScore;
+
     public Interview(Member member) {
         this.member = member;
     }
 
-    public void feedbackTotal(String totalFeedback) {
+    public void evaluate(String totalFeedback, Integer totalScore) {
         this.totalFeedback = totalFeedback;
+        this.totalScore = totalScore;
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/request/GptRequest.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/request/GptRequest.java
@@ -12,23 +12,39 @@ public record GptRequest(
         ToolChoice toolChoice
 ) {
 
-    public static GptRequest createGptRequest(List<Message> messages) {
-        return new GptRequest("gpt-4o-mini", messages, createTools(), createToolChoice());
+    public static GptRequest createProceedGptRequest(List<Message> messages) {
+        return new GptRequest("gpt-4o-mini", messages, createProceedTools(), createProceedToolChoice());
     }
 
-    private static List<Tool> createTools() {
-        return List.of(new Tool("function", new GptFunction("generate_feedback", createParams())));
+    public static GptRequest createEndGptRequest(List<Message> messages) {
+        return new GptRequest("gpt-4o-mini", messages, createEndTools(), createEndToolChoice());
     }
 
-    private static GptFunctionParameters createParams() {
+    private static List<Tool> createProceedTools() {
+        return List.of(new Tool("function", new GptFunction("generate_feedback", createProceedParams())));
+    }
+
+    private static List<Tool> createEndTools() {
+        return List.of(new Tool("function", new GptFunction("generate_total_feedback", createEndParams())));
+    }
+
+    private static GptFunctionParameters createProceedParams() {
         return new GptFunctionParameters(
                 "object",
-                createProperties(),
+                createProceedProperties(),
                 List.of("rank", "feedback", "next_question")
         );
     }
 
-    private static Map<String, FunctionParamProperty> createProperties() {
+    private static GptFunctionParameters createEndParams() {
+        return new GptFunctionParameters(
+                "object",
+                createEndProperties(),
+                List.of("rank", "feedback", "total_feedback")
+        );
+    }
+
+    private static Map<String, FunctionParamProperty> createProceedProperties() {
         return Map.of(
                 "rank", new FunctionParamProperty("string"),
                 "feedback", new FunctionParamProperty("string"),
@@ -36,7 +52,19 @@ public record GptRequest(
         );
     }
 
-    private static ToolChoice createToolChoice() {
+    private static Map<String, FunctionParamProperty> createEndProperties() {
+        return Map.of(
+                "rank", new FunctionParamProperty("string"),
+                "feedback", new FunctionParamProperty("string"),
+                "total_feedback", new FunctionParamProperty("string")
+        );
+    }
+
+    private static ToolChoice createProceedToolChoice() {
         return new ToolChoice("function", new ToolChoiceFunction("generate_feedback"));
+    }
+
+    private static ToolChoice createEndToolChoice() {
+        return new ToolChoice("function", new ToolChoiceFunction("generate_total_feedback"));
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptEndResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptEndResponse.java
@@ -1,0 +1,11 @@
+package com.samhap.kokomen.interview.external.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GptEndResponse(
+        String rank,
+        String feedback,
+        @JsonProperty("total_feedback")
+        String totalFeedback
+) {
+}

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptFunctionCall.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptFunctionCall.java
@@ -7,10 +7,19 @@ public record GptFunctionCall(
         String arguments
 ) {
 
-    public GptAnswerResponse toGptAnswerResponse() {
+    public GptProceedResponse toGptProceedResponse() {
         try {
             ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(arguments, GptAnswerResponse.class);
+            return mapper.readValue(arguments, GptProceedResponse.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("GPT 응답 파싱 실패", e);
+        }
+    }
+
+    public GptEndResponse toGptEndResponse() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(arguments, GptEndResponse.class);
         } catch (Exception e) {
             throw new IllegalArgumentException("GPT 응답 파싱 실패", e);
         }

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptProceedResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptProceedResponse.java
@@ -2,7 +2,7 @@ package com.samhap.kokomen.interview.external.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record GptAnswerResponse(
+public record GptProceedResponse(
         String rank,
         String feedback,
         @JsonProperty("next_question")

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/GptResponse.java
@@ -6,12 +6,21 @@ public record GptResponse(
         List<Choice> choices
 ) {
 
-    public GptAnswerResponse toGptAnswerResponse() {
+    public GptProceedResponse toGptProceedResponse() {
         return choices.get(0)
                 .message()
                 .toolCalls()
                 .get(0)
                 .function()
-                .toGptAnswerResponse();
+                .toGptProceedResponse();
+    }
+
+    public GptEndResponse toGptEndResponse() {
+        return choices.get(0)
+                .message()
+                .toolCalls()
+                .get(0)
+                .function()
+                .toGptEndResponse();
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -11,7 +11,8 @@ import com.samhap.kokomen.interview.domain.RootQuestion;
 import com.samhap.kokomen.interview.external.GptClient;
 import com.samhap.kokomen.interview.external.dto.request.GptRequest;
 import com.samhap.kokomen.interview.external.dto.request.Message;
-import com.samhap.kokomen.interview.external.dto.response.GptAnswerResponse;
+import com.samhap.kokomen.interview.external.dto.response.GptEndResponse;
+import com.samhap.kokomen.interview.external.dto.response.GptProceedResponse;
 import com.samhap.kokomen.interview.external.dto.response.GptResponse;
 import com.samhap.kokomen.interview.repository.AnswerRepository;
 import com.samhap.kokomen.interview.repository.InterviewCategoryRepository;
@@ -97,21 +98,79 @@ public class InterviewService {
 
         List<Message> messages = new ArrayList<>();
 
+        if (questions.size() < MAX_QUESTION_COUNT) {
+            messages.add(
+                    new Message("system", """
+                                            너는 면접관이야. 존댓말로 대답해줘.
+                                            질문과 답변을 전달해주면, 맨 마지막 답변에 대해서만 feedback 필드에 피드백을 줘.
+                                            이 때 피드백은 각 답변에 대해 랭크를 매겨줘야 하는데, A+~F 대학 학점 중 하나로 매겨서 rank 필드에 줘. 기준은 다음과 같아.
+                                            A: 딱히 흠잡을 곳이 없고, 논리적으로 잘 설명한 경우. 질문의 요지에 대한 핵심도 잘 파악한 경우
+                                            B: 논리적으로 설명이 맞고, 질문의 요지에 대해서도 잘 대답했지만, 중요한 개념을 빠뜨린 것이 있는 경우. 예를 들어, 객체지향의 특징이면 다형성, 캡슐화, 상속, 추상화인데, 1~3개만 설명한 경우. 또는 용어만 헷갈린 경우.
+                                            C: 논리적으로 잘못된 부분이 존재하지만, 질문의 요지에 대해서는 제대로 파악한 경우. 물론 논리가 너무 많이 잘못됐다면 D로 갈수도 있음. 예를 들어 객체지향 특징에서 다형성, 캡슐화, 상속, 추상화에 대해 설명했지만, 그 중 하나 이상에 대해 논리적으로 잘못 설명한 경우.
+                                            D: 질문의 요지는 제대로 파악했지만, 논리적으로 모두 틀린 경우. 예를 들어 객체지향에서 다형성, 캡슐화, 상속, 추상화에 대해 설명했지만 모두 틀린 경우.
+                                            F: 전혀 다른 대답을했거나, 논리적으로 완전히 틀렸거나, 대답 자체를 안한 경우. 예를 들어 객체지향의 특징에 대해 설명하라 했지만 자바 예외처리에 대해 설명한 경우.
+                                            또한 코멘트로도 피드백을 주는데, 최대한 자세하게 코멘트해줘.
+                                            그와 동시에 꼬리 질문을 next_question 필드에 줘.
+                            """)
+            );
+            addMessages(answerRequest, answers, messages, lastQuestion);
+
+            GptResponse gptResponse = gptClient.requestToGpt(GptRequest.createProceedGptRequest(messages));
+
+            GptProceedResponse gptProceedResponse = gptResponse.toGptProceedResponse();
+
+            Answer lastAnswer = new Answer(
+                    lastQuestion, answerRequest.answer(),
+                    AnswerRank.valueOf(gptProceedResponse.rank()),
+                    gptProceedResponse.feedback()
+            );
+
+            // TODO: 마지막 답변 여부 체크
+            Question nextQuestion = new Question(
+                    interview, lastQuestion.getRootQuestion(), gptProceedResponse.nextQuestion()
+            );
+
+            answerRepository.save(lastAnswer);
+            questionRepository.save(nextQuestion);
+
+            return Optional.of(new NextQuestionResponse(nextQuestion.getContent()));
+        }
+
         messages.add(
                 new Message("system", """
                                         너는 면접관이야. 존댓말로 대답해줘.
-                                        질문과 답변을 전달해주면, 맨 마지막 답변에 대해서만 피드백을 줘.
-                                        이 때 피드백은 각 답변에 대해 랭크를 매겨줘야 하는데, A+~F 대학 학점 중 하나로 매겨줘. 기준은 다음과 같아.
+                                        질문과 답변을 전달해주면, 맨 마지막 답변에 대해서만 feedback 필드에 피드백을 줘.
+                                        이 때 피드백은 각 답변에 대해 랭크를 매겨줘야 하는데, A+~F 대학 학점 중 하나로 매겨서 rank 필드에 줘. 기준은 다음과 같아.
                                         A: 딱히 흠잡을 곳이 없고, 논리적으로 잘 설명한 경우. 질문의 요지에 대한 핵심도 잘 파악한 경우
                                         B: 논리적으로 설명이 맞고, 질문의 요지에 대해서도 잘 대답했지만, 중요한 개념을 빠뜨린 것이 있는 경우. 예를 들어, 객체지향의 특징이면 다형성, 캡슐화, 상속, 추상화인데, 1~3개만 설명한 경우. 또는 용어만 헷갈린 경우.
                                         C: 논리적으로 잘못된 부분이 존재하지만, 질문의 요지에 대해서는 제대로 파악한 경우. 물론 논리가 너무 많이 잘못됐다면 D로 갈수도 있음. 예를 들어 객체지향 특징에서 다형성, 캡슐화, 상속, 추상화에 대해 설명했지만, 그 중 하나 이상에 대해 논리적으로 잘못 설명한 경우.
                                         D: 질문의 요지는 제대로 파악했지만, 논리적으로 모두 틀린 경우. 예를 들어 객체지향에서 다형성, 캡슐화, 상속, 추상화에 대해 설명했지만 모두 틀린 경우.
                                         F: 전혀 다른 대답을했거나, 논리적으로 완전히 틀렸거나, 대답 자체를 안한 경우. 예를 들어 객체지향의 특징에 대해 설명하라 했지만 자바 예외처리에 대해 설명한 경우.
                                         또한 코멘트로도 피드백을 주는데, 최대한 자세하게 코멘트해줘.
-                                        그와 동시에 꼬리 질문도 해줘.
+                                        그리고 지금까지 준 모든 질문 답변에 대한 총 피드백을 total_feedback 필드에 줘.
+                                        이때 최대한 자세하게 해줘. 최대 2000자인데, 이 지원자가 전체적으로 어느 부분이 부족했는지, 어떻게 보완하면 좋을지 알려줘.
                         """)
         );
+        addMessages(answerRequest, answers, messages, lastQuestion);
 
+        GptResponse gptResponse = gptClient.requestToGpt(GptRequest.createEndGptRequest(messages));
+
+        GptEndResponse gptEndResponse = gptResponse.toGptEndResponse();
+
+        Answer lastAnswer = new Answer(
+                lastQuestion, answerRequest.answer(),
+                AnswerRank.valueOf(gptEndResponse.rank()),
+                gptEndResponse.feedback()
+        );
+
+        answerRepository.save(lastAnswer);
+        interview.feedbackTotal(gptEndResponse.totalFeedback());
+
+        return Optional.empty();
+    }
+
+    private void addMessages(AnswerRequest answerRequest, List<Answer> answers, List<Message> messages,
+                             Question lastQuestion) {
         answers.forEach(answer -> {
             messages.add(new Message("assistant", answer.getQuestion().getContent()));
             messages.add(new Message("user", answer.getContent()));
@@ -119,31 +178,6 @@ public class InterviewService {
 
         messages.add(new Message("assistant", lastQuestion.getContent()));
         messages.add(new Message("user", answerRequest.answer()));
-
-        GptResponse gptResponse = gptClient.requestToGpt(GptRequest.createGptRequest(messages));
-
-        GptAnswerResponse gptAnswerResponse = gptResponse.toGptAnswerResponse();
-
-        Answer lastAnswer = new Answer(
-                lastQuestion, answerRequest.answer(),
-                AnswerRank.valueOf(gptAnswerResponse.rank()),
-                gptAnswerResponse.feedback()
-        );
-
-        // TODO: 마지막 답변 여부 체크
-        Question nextQuestion = new Question(
-                interview, lastQuestion.getRootQuestion(), gptAnswerResponse.nextQuestion()
-        );
-
-        answerRepository.save(lastAnswer);
-
-        if (questions.size() >= MAX_QUESTION_COUNT) {
-            return Optional.empty();
-        }
-
-        questionRepository.save(nextQuestion);
-
-        return Optional.of(new NextQuestionResponse(nextQuestion.getContent()));
     }
 }
 

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/FeedbackResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/FeedbackResponse.java
@@ -1,0 +1,25 @@
+package com.samhap.kokomen.interview.service.dto;
+
+import com.samhap.kokomen.interview.domain.Answer;
+import com.samhap.kokomen.interview.domain.AnswerRank;
+
+public record FeedbackResponse(
+        Long questionId,
+        Long answerId,
+        String question,
+        String answer,
+        AnswerRank answerRank,
+        String answerFeedback
+) {
+
+    public static FeedbackResponse from(Answer answer) {
+        return new FeedbackResponse(
+                answer.getQuestion().getId(),
+                answer.getId(),
+                answer.getQuestion().getContent(),
+                answer.getContent(),
+                answer.getAnswerRank(),
+                answer.getFeedback()
+        );
+    }
+}

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewTotalResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewTotalResponse.java
@@ -1,0 +1,30 @@
+package com.samhap.kokomen.interview.service.dto;
+
+import com.samhap.kokomen.interview.domain.Interview;
+import com.samhap.kokomen.member.domain.Member;
+import java.util.List;
+
+public record InterviewTotalResponse(
+        List<FeedbackResponse> feedbacks,
+        Integer totalScore,
+        Integer userCurScore,
+        Integer userPrevScore,
+        String userCurRank,
+        String userPrevRank
+) {
+
+    public static InterviewTotalResponse of(
+            List<FeedbackResponse> feedbacks,
+            Interview interview,
+            Member member
+    ) {
+        return new InterviewTotalResponse(
+                feedbacks,
+                interview.getTotalScore(),
+                member.getScore(),
+                member.getScore() - interview.getTotalScore(),
+                "BRONZE",
+                "BRONZE"
+        );
+    }
+}

--- a/src/main/java/com/samhap/kokomen/member/domain/Member.java
+++ b/src/main/java/com/samhap/kokomen/member/domain/Member.java
@@ -7,8 +7,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Member extends BaseEntity {
@@ -21,7 +23,15 @@ public class Member extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
     public Member(String name) {
         this.name = name;
+        this.score = 0;
+    }
+
+    public void updateScore(Integer updateAmount) {
+        this.score += updateAmount;
     }
 }

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -20,8 +20,8 @@ import com.samhap.kokomen.interview.domain.Question;
 import com.samhap.kokomen.interview.domain.RootQuestion;
 import com.samhap.kokomen.interview.external.dto.request.GptRequest;
 import com.samhap.kokomen.interview.external.dto.response.Choice;
-import com.samhap.kokomen.interview.external.dto.response.GptAnswerResponse;
 import com.samhap.kokomen.interview.external.dto.response.GptFunctionCall;
+import com.samhap.kokomen.interview.external.dto.response.GptProceedResponse;
 import com.samhap.kokomen.interview.external.dto.response.GptResponse;
 import com.samhap.kokomen.interview.external.dto.response.Message;
 import com.samhap.kokomen.interview.external.dto.response.ToolCall;
@@ -97,7 +97,7 @@ class InterviewControllerTest extends BaseControllerTest {
                 }
                 """.formatted(nextQuestion);
 
-        GptAnswerResponse gptAnswerResponse = new GptAnswerResponse(
+        GptProceedResponse gptProceedResponse = new GptProceedResponse(
                 AnswerRank.D.name(),
                 "똑바로 대답하세요.",
                 nextQuestion
@@ -109,7 +109,7 @@ class InterviewControllerTest extends BaseControllerTest {
                                 new Message(
                                         List.of(new ToolCall(new GptFunctionCall(
                                                 "generate_feedback",
-                                                objectMapper.writeValueAsString(gptAnswerResponse)
+                                                objectMapper.writeValueAsString(gptProceedResponse)
                                         )))
                                 )
                         ))

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -134,6 +135,84 @@ class InterviewControllerTest extends BaseControllerTest {
                         ),
                         responseFields(
                                 fieldWithPath("next_question").description("다음 질문")
+                        )
+                ));
+    }
+
+    @Test
+    void 인터뷰에_대한_최종_결과를_조회한다() throws Exception {
+        // given
+        Member member = memberRepository.save(new Member("NAK"));
+        Interview interview = interviewRepository.save(new Interview(member));
+        RootQuestion rootQuestion = rootQuestionRepository.save(new RootQuestion("자바의 특징은 무엇인가요?"));
+        Question question1 = questionRepository.save(new Question(interview, rootQuestion, rootQuestion.getContent()));
+        Answer answer1 = answerRepository.save(new Answer(question1, "자바는 객체지향 프로그래밍 언어입니다.", AnswerRank.C, "부족합니다."));
+        Question question2 = questionRepository.save(new Question(interview, rootQuestion, "객체지향의 특징을 설명해주세요."));
+        Answer answer2 = answerRepository.save(new Answer(question2, "객체가 각자 책임집니다.", AnswerRank.C, "부족합니다."));
+        Question question3 = questionRepository.save(new Question(interview, rootQuestion, "객체는 무엇인가요?"));
+        Answer answer3 = answerRepository.save(new Answer(question3, "클래스의 인스턴스 입니다.", AnswerRank.C, "부족합니다."));
+        interview.evaluate("제대로 좀 공부 해라.", 10);
+        interviewRepository.save(interview);
+        member.updateScore(10);
+        memberRepository.save(member);
+
+        String responseJson = """
+                {
+                	"feedbacks": [
+                		{
+                			"question_id": 1,
+                			"answer_id": 1,
+                			"question": "자바의 특징은 무엇인가요?",
+                			"answer": "자바는 객체지향 프로그래밍 언어입니다.",
+                			"answer_rank": "C",
+                			"answer_feedback": "부족합니다."
+                		},
+                		{
+                			"question_id": 2,
+                			"answer_id": 2,
+                			"question": "객체지향의 특징을 설명해주세요.",
+                			"answer": "객체가 각자 책임집니다.",
+                			"answer_rank": "C",
+                			"answer_feedback": "부족합니다."
+                		},
+                		{
+                			"question_id": 3,
+                			"answer_id": 3,
+                			"question": "객체는 무엇인가요?",
+                			"answer": "클래스의 인스턴스 입니다.",
+                			"answer_rank": "C",
+                			"answer_feedback": "부족합니다."
+                		}
+                	],
+                	"total_score": 10,
+                	"user_cur_score": 10,
+                	"user_prev_score": 0,
+                	"user_prev_rank": "BRONZE",
+                	"user_cur_rank": "BRONZE"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(get("/api/v1/interviews/{interview_id}/result", interview.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().json(responseJson))
+                .andDo(document("interview-findTotalFeedbacks",
+                        pathParameters(
+                                parameterWithName("interview_id").description("인터뷰 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("feedbacks").description("피드백 목록"),
+                                fieldWithPath("feedbacks[].question_id").description("질문 ID"),
+                                fieldWithPath("feedbacks[].answer_id").description("답변 ID"),
+                                fieldWithPath("feedbacks[].question").description("질문 내용"),
+                                fieldWithPath("feedbacks[].answer").description("답변 내용"),
+                                fieldWithPath("feedbacks[].answer_rank").description("답변 등급"),
+                                fieldWithPath("feedbacks[].answer_feedback").description("답변 피드백"),
+                                fieldWithPath("total_score").description("인터뷰 총 점수"),
+                                fieldWithPath("user_cur_score").description("현재 사용자 점수"),
+                                fieldWithPath("user_prev_score").description("이전 사용자 점수"),
+                                fieldWithPath("user_prev_rank").description("이전 사용자 랭크"),
+                                fieldWithPath("user_cur_rank").description("현재 사용자 랭크")
                         )
                 ));
     }


### PR DESCRIPTION
# 작업 내용
- 인터뷰 각 질문에 대한 피드백과 종합 피드백을 조회하는 기능 구현
- 마지막 질문에 대한 답변을 하면, 기존 API 수정
  - GPT에게 종합 피드백을 받고, 꼬리 질문을 받지 않도록 수정
  - 인터뷰에 대한 점수를 합산하여 사용자의 점수에 반영

# 참고 사항
코드가 어마무시하게 더럽네요..
MVP 구현을 위해 빠르게 개발합니다.

다음주에 뜨겁게 리팩터링 하시죠!! ㅎㅎ