### PR TITLE
[Fix] - GPT가 중복된 꼬리질문을 응답하는 버그 수정

### DIFF
--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -135,7 +135,7 @@ public class InterviewService {
             answerRepository.save(lastAnswer);
             questionRepository.save(nextQuestion);
 
-            return Optional.of(new NextQuestionResponse(nextQuestion.getContent()));
+            return Optional.of(NextQuestionResponse.createFollowingQuestionResponse(nextQuestion));
         }
 
         messages.add(

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/NextQuestionResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/NextQuestionResponse.java
@@ -1,6 +1,18 @@
 package com.samhap.kokomen.interview.service.dto;
 
+import com.samhap.kokomen.interview.domain.Question;
+
 public record NextQuestionResponse(
-        String nextQuestion
+        Long questionId,
+        String question,
+        boolean isRoot
 ) {
+
+    public static NextQuestionResponse createFollowingQuestionResponse(Question question) {
+        return new NextQuestionResponse(
+                question.getId(),
+                question.getContent(),
+                false
+        );
+    }
 }

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -94,7 +94,9 @@ class InterviewControllerTest extends BaseControllerTest {
 
         String responseJson = """
                 {
-                  "next_question": "%s"
+                  "question_id": 3,
+                  "question": "%s",
+                  "is_root": false
                 }
                 """.formatted(nextQuestion);
 
@@ -134,7 +136,9 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("answer").description("사용자가 작성한 답변")
                         ),
                         responseFields(
-                                fieldWithPath("next_question").description("다음 질문")
+                                fieldWithPath("question_id").description("다음 질문 id"),
+                                fieldWithPath("question").description("다음 질문 내용"),
+                                fieldWithPath("is_root").description("루트 질문 여부")
                         )
                 ));
     }


### PR DESCRIPTION
# 작업 내용
- GPT가 중복된 꼬리 질문을 응답하지 않도록 명령문 수정
- 인터뷰 진행 응답 API response 명세를 규약에 맞게 변경

# 참고 사항
