### PR TITLE
[Feat] - 인터뷰 진행 시 인가 기능 구현

### DIFF
--- a/src/main/java/com/samhap/kokomen/global/config/WebConfig.java
+++ b/src/main/java/com/samhap/kokomen/global/config/WebConfig.java
@@ -1,7 +1,10 @@
 package com.samhap.kokomen.global.config;
 
+import com.samhap.kokomen.global.infrastructure.MemberAuthArgumentResolver;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -21,5 +24,10 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MemberAuthArgumentResolver());
     }
 }

--- a/src/main/java/com/samhap/kokomen/global/infrastructure/MemberAuthArgumentResolver.java
+++ b/src/main/java/com/samhap/kokomen/global/infrastructure/MemberAuthArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.samhap.kokomen.global.infrastructure;
+
+import com.samhap.kokomen.global.dto.MemberAuth;
+import com.samhap.kokomen.global.exception.UnauthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(MemberAuth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            throw new UnauthorizedException("로그인이 필요합니다");
+        }
+
+        Long memberId = (Long) session.getAttribute("MEMBER_ID");
+        if (memberId == null) {
+            throw new IllegalStateException("세션에 MEMBER_ID가 없습니다.");
+        }
+
+        return new MemberAuth(memberId);
+    }
+}

--- a/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
+++ b/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
@@ -25,28 +25,29 @@ public class InterviewController {
 
     @PostMapping
     public ResponseEntity<InterviewResponse> startInterview(
-            @RequestBody InterviewRequest interviewRequest
+            @RequestBody InterviewRequest interviewRequest,
+            MemberAuth memberAuth
     ) {
-        // TODO: MemberAuth를 활용해서 인터뷰를 시작하는 유저의 정보를 가져와야 함
-        return ResponseEntity.ok(interviewService.startInterview(interviewRequest, new MemberAuth(1L)));
+        return ResponseEntity.ok(interviewService.startInterview(interviewRequest, memberAuth));
     }
 
-    // TODO: MemberAuth를 활용해서 인터뷰를 진행하는 유저의 정보를 가져와야 함
     @PostMapping("/{interviewId}/questions/{curQuestionId}/answers")
     public ResponseEntity<?> proceedInterview(
             @PathVariable Long interviewId,
             @PathVariable Long curQuestionId,
-            @RequestBody AnswerRequest answerRequest
+            @RequestBody AnswerRequest answerRequest,
+            MemberAuth memberAuth
     ) {
-        return interviewService.proceedInterview(interviewId, curQuestionId, answerRequest, new MemberAuth(1L))
+        return interviewService.proceedInterview(interviewId, curQuestionId, answerRequest, memberAuth)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     @GetMapping("/{interviewId}/result")
     public ResponseEntity<InterviewTotalResponse> findTotalFeedbacks(
-            @PathVariable Long interviewId
+            @PathVariable Long interviewId,
+            MemberAuth memberAuth
     ) {
-        return ResponseEntity.ok(interviewService.findTotalFeedbacks(interviewId, new MemberAuth(1L)));
+        return ResponseEntity.ok(interviewService.findTotalFeedbacks(interviewId, memberAuth));
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
@@ -65,6 +65,10 @@ public class Interview extends BaseEntity {
         }
     }
 
+    public boolean isInterviewee(Member member) {
+        return this.member.getId().equals(member.getId());
+    }
+
     public void evaluate(String totalFeedback, Integer totalScore) {
         this.totalFeedback = totalFeedback;
         this.totalScore = totalScore;

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -2,6 +2,8 @@ package com.samhap.kokomen.interview.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -79,11 +81,15 @@ class InterviewControllerTest extends BaseControllerTest {
                         "/api/v1/interviews")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestJson)
+                        .header("Cookie", "JSESSIONID=" + session.getId())
                         .session(session)
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
                 .andDo(document("interview-startInterview",
+                        requestHeaders(
+                                headerWithName("Cookie").description("로그인 세션을 위한 JSESSIONID 쿠키")
+                        ),
                         requestFields(
                                 fieldWithPath("category").description("인터뷰 카테고리"),
                                 fieldWithPath("max_question_count").description("최대 질문 개수")
@@ -136,6 +142,7 @@ class InterviewControllerTest extends BaseControllerTest {
                         question2.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestJson)
+                        .header("Cookie", "JSESSIONID=" + session.getId())
                         .session(session)
                 )
                 .andExpect(status().isOk())
@@ -144,6 +151,9 @@ class InterviewControllerTest extends BaseControllerTest {
                         pathParameters(
                                 parameterWithName("interview_id").description("인터뷰 ID"),
                                 parameterWithName("question_id").description("질문 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName("Cookie").description("로그인 세션을 위한 JSESSIONID 쿠키")
                         ),
                         requestFields(
                                 fieldWithPath("answer").description("사용자가 작성한 답변")
@@ -216,12 +226,18 @@ class InterviewControllerTest extends BaseControllerTest {
                 """;
 
         // when & then
-        mockMvc.perform(get("/api/v1/interviews/{interview_id}/result", interview.getId()).session(session))
+        mockMvc.perform(get(
+                        "/api/v1/interviews/{interview_id}/result", interview.getId())
+                        .header("Cookie", "JSESSIONID=" + session.getId())
+                        .session(session))
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
                 .andDo(document("interview-findTotalFeedbacks",
                         pathParameters(
                                 parameterWithName("interview_id").description("인터뷰 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName("Cookie").description("로그인 세션을 위한 JSESSIONID 쿠키")
                         ),
                         responseFields(
                                 fieldWithPath("feedbacks").description("피드백 목록"),

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -35,6 +35,7 @@ import com.samhap.kokomen.member.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 
 class InterviewControllerTest extends BaseControllerTest {
 
@@ -53,6 +54,8 @@ class InterviewControllerTest extends BaseControllerTest {
     void 인터뷰를_생성하면_루트_질문을_바탕으로_질문도_생성된다() throws Exception {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER_ID", member.getId());
         String rootQuestionContent = "부팅 과정에 대해 설명해주세요.";
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().content(rootQuestionContent).build());
 
@@ -76,6 +79,7 @@ class InterviewControllerTest extends BaseControllerTest {
                         "/api/v1/interviews")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestJson)
+                        .session(session)
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
@@ -96,6 +100,8 @@ class InterviewControllerTest extends BaseControllerTest {
     void 인터뷰_답변을_전달하면_인터뷰에_대한_평가를_받고_다음_질문을_응답한다() throws Exception {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER_ID", member.getId());
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
         Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).build());
         Question question1 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content(rootQuestion.getContent()).build());
@@ -130,6 +136,7 @@ class InterviewControllerTest extends BaseControllerTest {
                         question2.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestJson)
+                        .session(session)
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
@@ -153,6 +160,8 @@ class InterviewControllerTest extends BaseControllerTest {
     void 인터뷰에_대한_최종_결과를_조회한다() throws Exception {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("MEMBER_ID", member.getId());
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().content("자바의 특징은 무엇인가요?").build());
         member.addScore(100);
         Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).build());
@@ -207,7 +216,7 @@ class InterviewControllerTest extends BaseControllerTest {
                 """;
 
         // when & then
-        mockMvc.perform(get("/api/v1/interviews/{interview_id}/result", interview.getId()))
+        mockMvc.perform(get("/api/v1/interviews/{interview_id}/result", interview.getId()).session(session))
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
                 .andDo(document("interview-findTotalFeedbacks",


### PR DESCRIPTION
# 작업 내용
- 인터뷰 소유권 설정: 인터뷰 생성 시 현재 로그인 사용자를 인터뷰어로 지정
- 접근 권한 제어: 인터뷰 진행, 인터뷰 결과 조회 API 호출 시 인터뷰 소유자 검증 로직 추가

# 참고 사항
