### PR TITLE
[Feat] - 회원 토큰 기능 구현

### DIFF
--- a/src/main/java/com/samhap/kokomen/KokomenApplication.java
+++ b/src/main/java/com/samhap/kokomen/KokomenApplication.java
@@ -3,8 +3,10 @@ package com.samhap.kokomen;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class KokomenApplication {
 

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -52,11 +52,18 @@ public class InterviewService {
     @Transactional
     public InterviewResponse startInterview(InterviewRequest interviewRequest, MemberAuth memberAuth) {
         Member member = readMember(memberAuth);
+        validateEnoughTokenCount(member, interviewRequest);
         RootQuestion rootQuestion = readRandomRootQuestion();
         Interview interview = interviewRepository.save(new Interview(member, rootQuestion, interviewRequest.maxQuestionCount()));
         Question question = questionRepository.save(new Question(interview, rootQuestion.getContent()));
 
         return new InterviewResponse(interview, question);
+    }
+
+    private void validateEnoughTokenCount(Member member, InterviewRequest interviewRequest) {
+        if (!member.hasEnoughTokenCount(interviewRequest.maxQuestionCount())) {
+            throw new BadRequestException("생성하려는 인터뷰의 최대 질문 수가 회원이 가진 토큰 개수를 초과합니다.");
+        }
     }
 
     // TODO: 랜덤 생성 로직 전략 패턴으로 추상화

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -81,6 +81,7 @@ public class InterviewService {
         Interview interview = readInterview(interviewId);
         validateInterviewee(interview, member);
         QuestionAndAnswers questionAndAnswers = createQuestionAndAnswers(curQuestionId, answerRequest, interview);
+        decreaseTokenCount(member);
         GptResponse gptResponse = gptClient.requestToGpt(questionAndAnswers);
         Answer curAnswer = saveCurrentAnswer(questionAndAnswers, gptResponse);
 
@@ -91,6 +92,13 @@ public class InterviewService {
 
         evaluateInterview(interview, questionAndAnswers, curAnswer, gptResponse, member);
         return Optional.empty();
+    }
+
+    private void decreaseTokenCount(Member member) {
+        int affectedRows = memberRepository.decreaseFreeTokenCount(member);
+        if (affectedRows == 0) {
+            throw new BadRequestException("회원의 토큰 개수가 부족해 인터뷰를 더 이상 진행할 수 없습니다.");
+        }
     }
 
     private QuestionAndAnswers createQuestionAndAnswers(Long curQuestionId, AnswerRequest answerRequest, Interview interview) {

--- a/src/main/java/com/samhap/kokomen/member/domain/Member.java
+++ b/src/main/java/com/samhap/kokomen/member/domain/Member.java
@@ -31,13 +31,21 @@ public class Member extends BaseEntity {
     @Column(name = "score", nullable = false)
     private Integer score;
 
+    @Column(name = "free_token_count", nullable = false)
+    private Integer freeTokenCount;
+
     public Member(Long kakaoId, String nickname) {
         this.kakaoId = kakaoId;
         this.nickname = nickname;
         this.score = 0;
+        this.freeTokenCount = 10; // TODO: @Scheduled에서 상수 선언하고 가져다 쓰기
     }
 
     public void addScore(Integer addendScore) {
         this.score += addendScore;
+    }
+
+    public boolean hasEnoughTokenCount(int maxQuestionCount) {
+        return this.freeTokenCount >= maxQuestionCount;
     }
 }

--- a/src/main/java/com/samhap/kokomen/member/domain/Member.java
+++ b/src/main/java/com/samhap/kokomen/member/domain/Member.java
@@ -17,6 +17,8 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Member extends BaseEntity {
 
+    public static final int DAILY_FREE_TOKEN_COUNT = 10;
+
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -38,7 +40,7 @@ public class Member extends BaseEntity {
         this.kakaoId = kakaoId;
         this.nickname = nickname;
         this.score = 0;
-        this.freeTokenCount = 10; // TODO: @Scheduled에서 상수 선언하고 가져다 쓰기
+        this.freeTokenCount = DAILY_FREE_TOKEN_COUNT;
     }
 
     public void addScore(Integer addendScore) {

--- a/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
+++ b/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
@@ -3,8 +3,14 @@ package com.samhap.kokomen.member.repository;
 import com.samhap.kokomen.member.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByKakaoId(Long kakaoId);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.freeTokenCount = m.freeTokenCount - 1 WHERE m = :member AND m.freeTokenCount > 0")
+    int decreaseFreeTokenCount(Member member);
 }

--- a/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
+++ b/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
@@ -13,4 +13,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Modifying
     @Query("UPDATE Member m SET m.freeTokenCount = m.freeTokenCount - 1 WHERE m = :member AND m.freeTokenCount > 0")
     int decreaseFreeTokenCount(Member member);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.freeTokenCount = :dailyFreeTokenCount")
+    int rechargeDailyFreeToken(int dailyFreeTokenCount);
 }

--- a/src/main/java/com/samhap/kokomen/member/service/MemberScheduler.java
+++ b/src/main/java/com/samhap/kokomen/member/service/MemberScheduler.java
@@ -1,0 +1,21 @@
+package com.samhap.kokomen.member.service;
+
+import com.samhap.kokomen.member.domain.Member;
+import com.samhap.kokomen.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class MemberScheduler {
+
+    private final MemberRepository memberRepository;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void rechargeDailyFreeToken() {
+        memberRepository.rechargeDailyFreeToken(Member.DAILY_FREE_TOKEN_COUNT);
+    }
+}

--- a/src/main/resources/db/migration/V2__add_free_token_count.sql
+++ b/src/main/resources/db/migration/V2__add_free_token_count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+    ADD COLUMN free_token_count INTEGER NOT NULL DEFAULT 10;

--- a/src/test/java/com/samhap/kokomen/global/fixture/member/MemberFixtureBuilder.java
+++ b/src/test/java/com/samhap/kokomen/global/fixture/member/MemberFixtureBuilder.java
@@ -6,8 +6,9 @@ public class MemberFixtureBuilder {
 
     private Long id;
     private Long kakaoId;
-    private String name;
+    private String nickname;
     private Integer score;
+    private Integer freeTokenCount;
 
     public static MemberFixtureBuilder builder() {
         return new MemberFixtureBuilder();
@@ -18,8 +19,13 @@ public class MemberFixtureBuilder {
         return this;
     }
 
-    public MemberFixtureBuilder name(String name) {
-        this.name = name;
+    public MemberFixtureBuilder kakaoId(Long kakaoId) {
+        this.kakaoId = kakaoId;
+        return this;
+    }
+
+    public MemberFixtureBuilder nickname(String nickname) {
+        this.nickname = nickname;
         return this;
     }
 
@@ -28,17 +34,19 @@ public class MemberFixtureBuilder {
         return this;
     }
 
-    public MemberFixtureBuilder kakaoId(Long kakaoId) {
-        this.kakaoId = kakaoId;
+    public MemberFixtureBuilder freeTokenCount(Integer freeTokenCount) {
+        this.freeTokenCount = freeTokenCount;
         return this;
     }
+
 
     public Member build() {
         return new Member(
                 id,
                 kakaoId != null ? kakaoId : 1L,
-                name != null ? name : "오상훈",
-                score != null ? score : 0
+                nickname != null ? nickname : "오상훈",
+                score != null ? score : 0,
+                freeTokenCount != null ? freeTokenCount : 10
         );
     }
 }

--- a/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.samhap.kokomen.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.samhap.kokomen.global.BaseTest;
+import com.samhap.kokomen.global.fixture.member.MemberFixtureBuilder;
+import com.samhap.kokomen.member.domain.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+class MemberRepositoryTest extends BaseTest {
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void free_token_count를_1_감소시킨다() {
+        // given
+        Member member = memberRepository.save(MemberFixtureBuilder.builder().freeTokenCount(1).build());
+
+        // when
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+        int affectedRows = memberRepository.decreaseFreeTokenCount(member);
+        transactionManager.commit(status);
+
+        // then
+        assertAll(
+                () -> assertThat(memberRepository.findById(member.getId()).get().getFreeTokenCount()).isZero(),
+                () -> assertThat(affectedRows).isEqualTo(1)
+        );
+    }
+
+    @Test
+    void free_token_count가_부족하면_0을_반환한다() {
+        // given
+        Member member = memberRepository.save(MemberFixtureBuilder.builder().freeTokenCount(0).build());
+
+        // when
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+        int affectedRows = memberRepository.decreaseFreeTokenCount(member);
+        transactionManager.commit(status);
+
+        // then
+        assertAll(
+                () -> assertThat(memberRepository.findById(member.getId()).get().getFreeTokenCount()).isZero(),
+                () -> assertThat(affectedRows).isEqualTo(0)
+        );
+    }
+}

--- a/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
@@ -52,4 +52,21 @@ class MemberRepositoryTest extends BaseTest {
                 () -> assertThat(affectedRows).isEqualTo(0)
         );
     }
+
+    @Test
+    void daily_free_token_count를_재충전한다() {
+        // given
+        Member member = memberRepository.save(MemberFixtureBuilder.builder().freeTokenCount(0).build());
+
+        // when
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+        int affectedRows = memberRepository.rechargeDailyFreeToken(Member.DAILY_FREE_TOKEN_COUNT);
+        transactionManager.commit(status);
+
+        // then
+        assertAll(
+                () -> assertThat(memberRepository.findById(member.getId()).get().getFreeTokenCount()).isEqualTo(Member.DAILY_FREE_TOKEN_COUNT),
+                () -> assertThat(affectedRows).isEqualTo(1)
+        );
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,7 +28,7 @@ spring:
     password: root
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
@@ -45,6 +45,6 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
# 작업 내용
- [x] `Member` 테이블에 `free_token_count` 추가
  - [x] flyway를 위한 `V2__.sql` 추가
- [x] 인터뷰 생성 시 `max_question_count <= free_token_count` 인지 검증 로직 구현
  - 나중에 결제 기능이 붙으면 `max_question_count <= free_token_count + paid_token_count`로 변경
- [x] `free_token_count--` 하고 LLM API 호출 
  - 현재 구현상 LLM API가 실패하면 트랜잭션이 모두 롤백되면서 자연스럽게 `free_token_count`가 복구됩니다.
  - 추후 트랜잭션 분리를 진행하면서 복구 로직을 다시 신경써볼 것 같습니다.
- [x] 모든 `Member`의 `free_token_count`를 매일 n개로 초기화 (일단 10개로 가정)
  - [ ] 서버의 타임존을 `Asia/Seoul`로 모두 변경

# 참고 사항
비즈니스 정책상으로 아직 명확히 정해지진 않았지만, 충분히 가정해도 될 것 같은 내용들을 정리해봤습니다.

1. `free_token_count`는 매일 n개로 초기화된다. 
  - 즉 `free_token_count`가 n개 초과되는 경우는 없다.

2. `free_token_count`를 우선적으로 소진하고 `paid_token_count`를 소진한다.

3. `xxx_token_count`는 LLM API를 호출할 때마다 1개씩 차감된다.
  - 인터뷰를 생성할 때 `max_question_count`만큼 한 번에 차감하는 것도 생각해봤지만, 인터뷰 중간에 사용자가 여러가지 이유로 이탈한 경우, 토큰 갯수를 돌려주기 위한 방법이 아직까지 구상되어 있지 않다는 점과 이게 꽤나 복잡해질 것 같다는 점을 고려해 LLM API 호출 시마다 1개씩 차감되는 방향으로 결정했습니다.

# 논의해볼 사항
- 인터뷰 생성 시, 또는 인터뷰 진행 시 토큰이 부족하면 이와 관련된 예외가 발생합니다. 특정 예외들의 경우엔 문서화하기로 했던 것 같은데, 기준이 기억이 안 나네요 허허

# 다음에 할 일
- 현재 LLM API 호출이 DB 트랜잭션 내부에서 동작하고 있습니다. prod에 모니터링을 달고 성능테스트를 해본 뒤, Facade 도입으로 트랜잭션을 분리하고 다시 또 성능테스트를 해보면 좋을 것 같습니다.
  - 커넥션 점유 시간, 현재 커넥션 사용량, 남은 커넥션 수, 커넥션 획득 대기중인 요청 수(이건 스프링부트의 HikariCP를 모니터링해야겠네요)도 모니터링하면 좋을 것 같습니다.
  - undo log가 DB memory 차지하는 양 모니터링 -> 근데 회원마다 자신의 정보만 건드리기 때문에 undo log가 쌓일만한 구석은 안 보이긴 합니다. 그래도 undo log 모니터링해두면 나중에 문제지점 찾는데 도움될 수도 있을 것 같아요.
