### PR TITLE
feat: 면접 카테고리 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/samhap/kokomen/category/controller/CategoryController.java
+++ b/src/main/java/com/samhap/kokomen/category/controller/CategoryController.java
@@ -2,7 +2,9 @@ package com.samhap.kokomen.category.controller;
 
 import com.samhap.kokomen.category.service.CategoryService;
 import com.samhap.kokomen.category.service.dto.CategoryResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,7 +17,7 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping
-    public CategoryResponse findCategories() {
-        return categoryService.findCategories();
+    public ResponseEntity<List<CategoryResponse>> findCategories() {
+        return ResponseEntity.ok(categoryService.findCategories());
     }
 }

--- a/src/main/java/com/samhap/kokomen/category/domain/Category.java
+++ b/src/main/java/com/samhap/kokomen/category/domain/Category.java
@@ -1,14 +1,62 @@
 package com.samhap.kokomen.category.domain;
 
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public enum Category {
-    ALGORITHM,
-    DATA_STRUCTURE,
-    DATABASE,
-    NETWORK,
-    OPERATING_SYSTEM,
+
+    ALGORITHM("알고리즘",
+            """
+                    알고리즘은 어떤 문제를 해결하기 위한 단계별 방법이나 절차를 의미합니다.
+                    예를 들어, 숫자 목록을 크기 순서대로 정렬하는 정렬 알고리즘이나, 원하는 데이터를 빠르게 찾는 탐색 알고리즘이 있습니다.
+                    또한, 그래프 알고리즘과 동적 프로그래밍 등 다양한 유형이 있으며,
+                    효율적인 알고리즘을 선택하고 구현하는 것은 프로그램의 성능을 좌우하는 중요한 요소입니다.
+                    """,
+            "kokomen-algorithm.png"),
+    DATA_STRUCTURE("자료구조",
+            """
+                    자료구조는 데이터를 효율적으로 저장하고 관리하기 위한 다양한 방법과 구조를 의미합니다.
+                    예를 들어, 배열과 리스트는 데이터를 순서대로 저장하는 데 쓰이고, 스택과 큐는 데이터를 쌓거나 줄 세우는 방식으로 관리합니다.
+                    또한, 트리와 그래프 같은 자료구조는 복잡한 관계나 연결 구조를 표현할 때 사용되며,
+                    적절한 자료구조를 선택하는 것은 빠르고 효율적인 알고리즘 구현의 핵심이 됩니다.
+                    """,
+            "kokomen-data-structure.png"),
+    DATABASE("데이터베이스",
+            """
+                    데이터베이스는 대량의 데이터를 효율적으로 저장하고 관리하는 시스템입니다.
+                    관계형 데이터베이스(RDBMS)는 테이블 구조와 SQL을 기반으로 데이터를 관리하고,
+                    NoSQL은 비정형 데이터와 대규모 분산 처리를 지원합니다.
+                    적절한 인덱스 설계는 빠른 데이터 조회와 시스템 성능에 중요한 영향을 미칩니다.
+                    """,
+            "kokomen-database.png"),
+    NETWORK("네트워크",
+            """
+                    네트워크는 여러 컴퓨터와 시스템이 서로 데이터를 주고받을 수 있도록 구성된 통신 구조입니다.
+                    네트워크 계층 구조(OSI 7계층, TCP/IP 4계층), 프로토콜(TCP, UDP, HTTP 등),
+                    라우팅, 패킷 전송 방식 등 다양한 개념을 이해하는 것이 네트워크의 핵심입니다.
+                    """,
+            "kokomen-network.png"),
+    OPERATING_SYSTEM("운영체제",
+            """
+                    운영체제는 하드웨어와 소프트웨어 자원을 효율적으로 관리하고, 사용자와 응용 프로그램이 시스템을 효과적으로 사용할 수 있도록 지원하는 핵심 소프트웨어입니다.
+                    프로세스 및 스레드 관리, 메모리 관리, 파일 시스템, 입출력(I/O) 제어, 그리고 CPU 스케줄링과 같은 기능을 담당합니다.
+                    OS의 구조와 동작 원리를 이해하는 것은 시스템 개발 및 최적화의 기초가 됩니다.
+                    """,
+            "kokomen-operating-system.png"),
     ;
+
+    private static final String BASE_URL = "https://d2ftfzru2cd49g.cloudfront.net/category-image/";
+
+    private final String title;
+    private final String description;
+    private final String imageUrl;
+
+    Category(String title, String description, String imageUrl) {
+        this.title = title;
+        this.description = description;
+        this.imageUrl = BASE_URL + imageUrl;
+    }
 
     private static final List<Category> CATEGORIES = List.of(values());
 

--- a/src/main/java/com/samhap/kokomen/category/service/CategoryService.java
+++ b/src/main/java/com/samhap/kokomen/category/service/CategoryService.java
@@ -2,12 +2,16 @@ package com.samhap.kokomen.category.service;
 
 import com.samhap.kokomen.category.domain.Category;
 import com.samhap.kokomen.category.service.dto.CategoryResponse;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CategoryService {
 
-    public CategoryResponse findCategories() {
-        return new CategoryResponse(Category.getCategories());
+    public List<CategoryResponse> findCategories() {
+        return Category.getCategories()
+                .stream()
+                .map(CategoryResponse::new)
+                .toList();
     }
 }

--- a/src/main/java/com/samhap/kokomen/category/service/dto/CategoryResponse.java
+++ b/src/main/java/com/samhap/kokomen/category/service/dto/CategoryResponse.java
@@ -1,9 +1,19 @@
 package com.samhap.kokomen.category.service.dto;
 
 import com.samhap.kokomen.category.domain.Category;
-import java.util.List;
 
 public record CategoryResponse(
-        List<Category> categories
+        String key,
+        String title,
+        String description,
+        String imageUrl
 ) {
+    public CategoryResponse(Category category) {
+        this(
+                category.name(),
+                category.getTitle(),
+                category.getDescription(),
+                category.getImageUrl()
+        );
+    }
 }

--- a/src/test/java/com/samhap/kokomen/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/category/controller/CategoryControllerTest.java
@@ -1,13 +1,13 @@
 package com.samhap.kokomen.category.controller;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.samhap.kokomen.category.domain.Category;
 import com.samhap.kokomen.global.BaseControllerTest;
 import org.junit.jupiter.api.Test;
 
@@ -17,22 +17,60 @@ class CategoryControllerTest extends BaseControllerTest {
     void 카테고리_목록을_조회한다() throws Exception {
         // given
         String expectedJson = """
-                {
-                  "categories": [
-                    "ALGORITHM",
-                    "DATA_STRUCTURE",
-                    "DATABASE",
-                    "NETWORK",
-                    "OPERATING_SYSTEM"
-                  ]
-                }
-                """;
+                [
+                  {
+                    "key": "%s",
+                    "title": "%s",
+                    "description": "%s",
+                    "image_url": "%s"
+                  },
+                  {
+                    "key": "%s",
+                    "title": "%s",
+                    "description": "%s",
+                    "image_url": "%s"
+                  },
+                  {
+                    "key": "%s",
+                    "title": "%s",
+                    "description": "%s",
+                    "image_url": "%s"
+                  },
+                  {
+                    "key": "%s",
+                    "title": "%s",
+                    "description": "%s",
+                    "image_url": "%s"
+                  },
+                  {
+                    "key": "%s",
+                    "title": "%s",
+                    "description": "%s",
+                    "image_url": "%s"
+                  }
+                ]
+                """.formatted(
+                Category.ALGORITHM.name(), Category.ALGORITHM.getTitle(),
+                Category.ALGORITHM.getDescription(), Category.ALGORITHM.getImageUrl(),
+                Category.DATA_STRUCTURE.name(), Category.DATA_STRUCTURE.getTitle(),
+                Category.DATA_STRUCTURE.getDescription(), Category.DATA_STRUCTURE.getImageUrl(),
+                Category.DATABASE.name(), Category.DATABASE.getTitle(),
+                Category.DATABASE.getDescription(), Category.DATABASE.getImageUrl(),
+                Category.NETWORK.name(), Category.NETWORK.getTitle(),
+                Category.NETWORK.getDescription(), Category.NETWORK.getImageUrl(),
+                Category.OPERATING_SYSTEM.name(), Category.OPERATING_SYSTEM.getTitle(),
+                Category.OPERATING_SYSTEM.getDescription(), Category.OPERATING_SYSTEM.getImageUrl());
 
         // when & then
         mockMvc.perform(get("/api/v1/categories"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedJson))
                 .andDo(document("category-findCategories",
-                        responseFields(fieldWithPath("categories").type(ARRAY).description("카테고리 목록"))));
+                        responseFields(
+                                fieldWithPath("[].key").description("카테고리 영문 키값"),
+                                fieldWithPath("[].title").description("카테고리 한글명"),
+                                fieldWithPath("[].description").description("카테고리 설명"),
+                                fieldWithPath("[].image_url").description("카테고리 이미지 URL")
+                        )));
     }
 }


### PR DESCRIPTION
# 작업 내용
- [x] `GET /api/v1/categories`의 응답을 아래 스펙에 맞게 수정
  - image -> image_url로 수정
![Image](https://github.com/user-attachments/assets/3713d26a-3cfc-46cd-b46e-e04e0f4af2a3)

- [x] S3에 카테고리별 이미지 업로드
- [x] CloudFront와 S3 연결
- [x] Enum에 카테고리 한글 이름, 카테고리 설명, image URL 모두 저장
  - [x] CategoryInfo와 같은 새로운 테이블 생성이 필요할 지 논의

# 참고 사항
- S3 버킷 만들어서 간단하게 GPT로 이미지 생성해서 업로드 해뒀습니다!
