### PR TITLE
refactor: Bedrock에서 사용하는 모델을 Claude 3 Sonnet -> 4로 변경

### DIFF
--- a/src/main/java/com/samhap/kokomen/interview/external/BedrockClient.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/BedrockClient.java
@@ -18,18 +18,18 @@ import software.amazon.awssdk.services.bedrockruntime.model.Message;
 @Component
 public class BedrockClient {
 
-    private static final String INFERENCE_PROFILE_ID = "apac.anthropic.claude-3-sonnet-20240229-v1:0";
+    private static final String INFERENCE_PROFILE_ID = "apac.anthropic.claude-sonnet-4-20250514-v1:0";
 
     private final BedrockRuntimeClient bedrockRuntimeClient;
 
     public BedrockResponse requestToBedrock(QuestionAndAnswers questionAndAnswers) {
         ConverseRequest converseRequest = createConverseRequest(questionAndAnswers);
-        
+
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
-        
+
         ConverseResponse converseResponse = bedrockRuntimeClient.converse(converseRequest);
-        
+
         stopWatch.stop();
         log.info("Bedrock API 호출 완료 - {}ms", stopWatch.getTotalTimeMillis());
 


### PR DESCRIPTION
# 작업 내용
- [x] `INFERENCE_PROFILE_ID` 상수에 들어가는 모델명 변경

# 참고 사항
- 현재 사용중인 Claude 3 Sonnet은 미국 리전까지 cross region inference로 요청해야 합니다.
- 따라서 미국까지의 RTT를 감수하고 있습니다. 3.5를 사용하면 그럴 필요가 없는 것 같습니다.
  - (GPT와 더 얘기해보니, 3.5에 cross region inference가 붙어있지 않음에도 미국 리전으로 간다고 합니다. 더 알아봐야 할 것 같습니다.)  
  - 어짜피 모두 미국 리전까지 가야하는거면, 4 버전을 사용하는게 나을 것 같습니다.
![Image](https://github.com/user-attachments/assets/ee902b11-49f2-4dc4-8a27-62e9b09e49cd)
- 4 버전을 사용하면 성능도 더 좋고, 가격도 동일하므로 4로 변경합니다. 
![Image](https://github.com/user-attachments/assets/0e460295-6000-44c3-ae3f-e9e915185764)