### PR TITLE
[Hotfix] - Redis 클러스터 세션 장애, 토큰 갯수 차감 오류 (main으로) 

### DIFF
--- a/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 public class Interview extends BaseEntity {
 
     public static final int MIN_ALLOWED_MAX_QUESTION_COUNT = 3;
-    public static final int MAX_ALLOWED_MAX_QUESTION_COUNT = 10;
+    public static final int MAX_ALLOWED_MAX_QUESTION_COUNT = 20;
 
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -83,10 +83,10 @@ public class InterviewService {
     // TODO: answer가 question을 들고 있는데, 영속성 컨텍스트를 활용해서 가져오는지 -> lazy 관련해서
     @Transactional
     public Optional<InterviewProceedResponse> proceedInterview(Long interviewId, Long curQuestionId, AnswerRequest answerRequest, MemberAuth memberAuth) {
+        decreaseTokenCount(memberAuth.memberId());
         Member member = readMember(memberAuth);
         Interview interview = readInterview(interviewId);
         validateInterviewee(interview, member);
-        decreaseTokenCount(member);
         QuestionAndAnswers questionAndAnswers = createQuestionAndAnswers(curQuestionId, answerRequest, interview);
 
         LLMResponse llmResponse = bedrockClient.requestToBedrock(questionAndAnswers);
@@ -101,8 +101,8 @@ public class InterviewService {
         return Optional.empty();
     }
 
-    private void decreaseTokenCount(Member member) {
-        int affectedRows = memberRepository.decreaseFreeTokenCount(member);
+    private void decreaseTokenCount(Long memberId) {
+        int affectedRows = memberRepository.decreaseFreeTokenCount(memberId);
         if (affectedRows == 0) {
             throw new BadRequestException("회원의 토큰 개수가 부족해 인터뷰를 더 이상 진행할 수 없습니다.");
         }

--- a/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
+++ b/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
@@ -11,8 +11,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByKakaoId(Long kakaoId);
 
     @Modifying
-    @Query("UPDATE Member m SET m.freeTokenCount = m.freeTokenCount - 1 WHERE m = :member AND m.freeTokenCount > 0")
-    int decreaseFreeTokenCount(Member member);
+    @Query("UPDATE Member m SET m.freeTokenCount = m.freeTokenCount - 1 WHERE m.id = :memberId AND m.freeTokenCount > 0")
+    int decreaseFreeTokenCount(Long memberId);
 
     @Modifying
     @Query("UPDATE Member m SET m.freeTokenCount = :dailyFreeTokenCount")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,8 +122,9 @@ spring:
       ddl-auto: validate
   data:
     redis:
-      host: ${REDIS_CLUSTER_ENDPOINT}
-      port: 6379
+      cluster:
+        nodes:
+          - ${REDIS_CLUSTER_ENDPOINT}
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID_PROD}

--- a/src/test/java/com/samhap/kokomen/interview/domain/InterviewTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/domain/InterviewTest.java
@@ -11,16 +11,16 @@ import org.junit.jupiter.params.provider.ValueSource;
 class InterviewTest {
 
     @ParameterizedTest
-    @ValueSource(ints = {2, 11})
-    void 최대_질문_개수가_3미만_10초과라면_예외가_발생한다(int maxQuestionCount) {
+    @ValueSource(ints = {2, 21})
+    void 최대_질문_개수가_3미만_20초과라면_예외가_발생한다(int maxQuestionCount) {
         assertThatThrownBy(() -> InterviewFixtureBuilder.builder().maxQuestionCount(maxQuestionCount).build())
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining("최대 질문 개수는");
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {3, 10})
-    void 최대_질문_개수가_2이상_10이하라면_인터뷰_생성에_성공한다(int maxQuestionCount) {
+    @ValueSource(ints = {3, 20})
+    void 최대_질문_개수가_2이상_20이하라면_인터뷰_생성에_성공한다(int maxQuestionCount) {
         assertThatCode(() -> InterviewFixtureBuilder.builder().maxQuestionCount(maxQuestionCount).build())
                 .doesNotThrowAnyException();
     }

--- a/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
@@ -77,7 +77,8 @@ class InterviewServiceTest extends BaseTest {
         // then
         assertAll(
                 () -> assertThat(actual).contains(expected),
-                () -> assertThat(questionRepository.existsById(question.getId() + 1)).isTrue()
+                () -> assertThat(questionRepository.existsById(question.getId() + 1)).isTrue(),
+                () -> assertThat(memberRepository.findById(member.getId()).get().getFreeTokenCount()).isEqualTo(member.getFreeTokenCount() - 1)
         );
     }
 
@@ -117,7 +118,8 @@ class InterviewServiceTest extends BaseTest {
                 () -> assertThat(questionRepository.existsById(question3.getId() + 1)).isFalse(),
                 () -> assertThat(interviewRepository.findById(interview.getId()).get().getTotalFeedback()).isEqualTo(totalFeedback),
                 () -> assertThat(interviewRepository.findById(interview.getId()).get().getTotalScore()).isEqualTo(answerRank.getScore() * 3),
-                () -> assertThat(memberRepository.findById(member.getId()).get().getScore()).isEqualTo(member.getScore() + answerRank.getScore() * 3)
+                () -> assertThat(memberRepository.findById(member.getId()).get().getScore()).isEqualTo(member.getScore() + answerRank.getScore() * 3),
+                () -> assertThat(memberRepository.findById(member.getId()).get().getFreeTokenCount()).isEqualTo(member.getFreeTokenCount() - 1)
         );
     }
 }

--- a/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
@@ -26,7 +26,7 @@ class MemberRepositoryTest extends BaseTest {
 
         // when
         TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
-        int affectedRows = memberRepository.decreaseFreeTokenCount(member);
+        int affectedRows = memberRepository.decreaseFreeTokenCount(member.getId());
         transactionManager.commit(status);
 
         // then
@@ -43,7 +43,7 @@ class MemberRepositoryTest extends BaseTest {
 
         // when
         TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
-        int affectedRows = memberRepository.decreaseFreeTokenCount(member);
+        int affectedRows = memberRepository.decreaseFreeTokenCount(member.getId());
         transactionManager.commit(status);
 
         // then


### PR DESCRIPTION
# 버그 내용
- Redis 클러스터에 세션을 연결할 때 장애 발생
2025-07-01 22:30:39.813 | Caused by: io.lettuce.core.RedisCommandExecutionException: MOVED 2284 redis-cluster-0001-001.redis-cluster.uqg8cb.apn2.cache.amazonaws.com:6379

- 토큰 갯수 차감 오류
  - Member 레코드에 `@Modifying `을 호출하고 나서, 같은 트랜잭션 내에서 같은 Member 엔티티에 대해 변경감지를 통해 점수를 업데이트하는 과정에서 토큰 갯수가 다시 원복되는 오류가 발생했습니다.
  - `(clearAutomatically = true)` 옵션을 주면 전체 영속성 컨텍스트가 비워지므로, 기존 메서드 순서를 유지하면 Interview를 조회한 후 영속성 컨텍스트가 비워지므로 Interview도 준영속 상태가 되어 변경감지가 되지 않습니다. (테스트 코드에서 확인함)
  - 따라서 `(clearAutomatically = true)` 옵션 없이 토큰을 차감하는 작업을 가장 먼저 수행해 문제를 해결했습니다. 어짜피 예외 터지면 트랜잭션 롤백되니까요.

- [x] cd-prod에 트리거 임시 변경한거 되돌리기
- [x] hotfix 브랜치를 main 뿐만 아니라 develop에도 머지시키기
# 스크린샷

# 참고 사항
