### PR TITLE
[Feat] - 랭킹 조회 API

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -43,6 +43,14 @@ include::{snippetsDir}/member-findMyProfile/http-response.adoc[]
 include::{snippetsDir}/member-findMyProfile/response-fields.adoc[]
 include::{snippetsDir}/member-findMyProfile/curl-request.adoc[]
 
+=== 랭킹 조회
+
+include::{snippetsDir}/member-findRanking/http-request.adoc[]
+include::{snippetsDir}/member-findRanking/query-parameters.adoc[]
+include::{snippetsDir}/member-findRanking/http-response.adoc[]
+include::{snippetsDir}/member-findRanking/response-fields.adoc[]
+include::{snippetsDir}/member-findRanking/curl-request.adoc[]
+
 === 멤버 프로필 변경
 
 include::{snippetsDir}/member-updateProfile/http-request.adoc[]

--- a/src/main/java/com/samhap/kokomen/member/controller/MemberController.java
+++ b/src/main/java/com/samhap/kokomen/member/controller/MemberController.java
@@ -4,8 +4,13 @@ import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.member.service.MemberService;
 import com.samhap.kokomen.member.service.dto.MyProfileResponse;
 import com.samhap.kokomen.member.service.dto.ProfileUpdateRequest;
+import com.samhap.kokomen.member.service.dto.RankingResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -34,5 +39,12 @@ public class MemberController {
     ) {
         memberService.updateProfile(memberAuth, profileUpdateRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/ranking")
+    public ResponseEntity<List<RankingResponse>> findRanking(
+            @PageableDefault(size = 30, sort = "score", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(memberService.findRanking(pageable));
     }
 }

--- a/src/main/java/com/samhap/kokomen/member/domain/Member.java
+++ b/src/main/java/com/samhap/kokomen/member/domain/Member.java
@@ -6,6 +6,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,6 +17,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(name = "member", indexes = {
+        @Index(name = "idx_member_score", columnList = "score")
+})
 public class Member extends BaseEntity {
 
     public static final int DAILY_FREE_TOKEN_COUNT = 20;

--- a/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
+++ b/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
@@ -1,13 +1,13 @@
 package com.samhap.kokomen.member.repository;
 
 import com.samhap.kokomen.member.domain.Member;
-import com.samhap.kokomen.member.service.dto.RankingResponse;
+import com.samhap.kokomen.member.service.dto.RankingProjection;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -21,11 +21,21 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("UPDATE Member m SET m.freeTokenCount = :dailyFreeTokenCount")
     int rechargeDailyFreeToken(int dailyFreeTokenCount);
 
-    @Query("""
-                SELECT new com.samhap.kokomen.member.service.dto.RankingResponse(m, COUNT(i.id))
-                FROM Member m
-                LEFT JOIN Interview i ON i.member.id = m.id
-                GROUP BY m
-            """)
-    List<RankingResponse> findRankings(Pageable pageable);
+    @Query(value = """
+                SELECT 
+                    m.id AS id,
+                    m.nickname AS nickname,
+                    m.score AS score,
+                    COUNT(i.id) AS interviewCount
+                FROM (
+                    SELECT id, nickname, score
+                    FROM member
+                    ORDER BY score DESC
+                    LIMIT :limit OFFSET :offset
+                ) m
+                LEFT JOIN interview i ON i.member_id = m.id
+                GROUP BY m.id, m.nickname, m.score
+                ORDER BY m.score DESC
+            """, nativeQuery = true)
+    List<RankingProjection> findRankings(@Param("limit") int limit, @Param("offset") int offset);
 }

--- a/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
+++ b/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
@@ -26,14 +26,15 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                     m.id AS id,
                     m.nickname AS nickname,
                     m.score AS score,
-                    COUNT(i.id) AS interviewCount
+                    COUNT(i.id) AS finishedInterviewCount
                 FROM (
                     SELECT id, nickname, score
                     FROM member
                     ORDER BY score DESC
                     LIMIT :limit OFFSET :offset
                 ) m
-                LEFT JOIN interview i ON i.member_id = m.id
+                LEFT JOIN interview i
+                    ON i.member_id = m.id AND i.interview_state = 'FINISHED'
                 GROUP BY m.id, m.nickname, m.score
                 ORDER BY m.score DESC
             """, nativeQuery = true)

--- a/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
+++ b/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
@@ -1,7 +1,10 @@
 package com.samhap.kokomen.member.repository;
 
 import com.samhap.kokomen.member.domain.Member;
+import com.samhap.kokomen.member.service.dto.RankingResponse;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +20,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Modifying
     @Query("UPDATE Member m SET m.freeTokenCount = :dailyFreeTokenCount")
     int rechargeDailyFreeToken(int dailyFreeTokenCount);
+
+    @Query("""
+                SELECT new com.samhap.kokomen.member.service.dto.RankingResponse(m, COUNT(i.id))
+                FROM Member m
+                LEFT JOIN Interview i ON i.member.id = m.id
+                GROUP BY m
+            """)
+    List<RankingResponse> findRankings(Pageable pageable);
 }

--- a/src/main/java/com/samhap/kokomen/member/service/MemberService.java
+++ b/src/main/java/com/samhap/kokomen/member/service/MemberService.java
@@ -7,8 +7,11 @@ import com.samhap.kokomen.member.repository.MemberRepository;
 import com.samhap.kokomen.member.service.dto.MemberResponse;
 import com.samhap.kokomen.member.service.dto.MyProfileResponse;
 import com.samhap.kokomen.member.service.dto.ProfileUpdateRequest;
+import com.samhap.kokomen.member.service.dto.RankingResponse;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -35,6 +38,10 @@ public class MemberService {
     public void updateProfile(MemberAuth memberAuth, ProfileUpdateRequest profileUpdateRequest) {
         Member member = readMember(memberAuth);
         member.updateProfile(profileUpdateRequest.nickname());
+    }
+
+    public List<RankingResponse> findRanking(Pageable pageable) {
+        return memberRepository.findRankings(pageable);
     }
 
     private Member readMember(MemberAuth memberAuth) {

--- a/src/main/java/com/samhap/kokomen/member/service/MemberService.java
+++ b/src/main/java/com/samhap/kokomen/member/service/MemberService.java
@@ -41,7 +41,9 @@ public class MemberService {
     }
 
     public List<RankingResponse> findRanking(Pageable pageable) {
-        return memberRepository.findRankings(pageable);
+        int limit = pageable.getPageSize();
+        int offset = (int) pageable.getOffset();
+        return RankingResponse.createRankingResponses(memberRepository.findRankings(limit, offset));
     }
 
     private Member readMember(MemberAuth memberAuth) {

--- a/src/main/java/com/samhap/kokomen/member/service/dto/RankingProjection.java
+++ b/src/main/java/com/samhap/kokomen/member/service/dto/RankingProjection.java
@@ -1,0 +1,11 @@
+package com.samhap.kokomen.member.service.dto;
+
+public interface RankingProjection {
+    Long getId();
+
+    String getNickname();
+
+    Integer getScore();
+
+    Long getInterviewCount();
+}

--- a/src/main/java/com/samhap/kokomen/member/service/dto/RankingProjection.java
+++ b/src/main/java/com/samhap/kokomen/member/service/dto/RankingProjection.java
@@ -7,5 +7,5 @@ public interface RankingProjection {
 
     Integer getScore();
 
-    Long getInterviewCount();
+    Long getFinishedInterviewCount();
 }

--- a/src/main/java/com/samhap/kokomen/member/service/dto/RankingResponse.java
+++ b/src/main/java/com/samhap/kokomen/member/service/dto/RankingResponse.java
@@ -6,14 +6,14 @@ public record RankingResponse(
         Long id,
         String nickname,
         Integer score,
-        Integer interviewCount
+        Integer finishedInterviewCount
 ) {
     public RankingResponse(RankingProjection rankingProjection) {
         this(
                 rankingProjection.getId(),
                 rankingProjection.getNickname(),
                 rankingProjection.getScore(),
-                rankingProjection.getInterviewCount().intValue()
+                rankingProjection.getFinishedInterviewCount().intValue()
         );
     }
 

--- a/src/main/java/com/samhap/kokomen/member/service/dto/RankingResponse.java
+++ b/src/main/java/com/samhap/kokomen/member/service/dto/RankingResponse.java
@@ -1,6 +1,6 @@
 package com.samhap.kokomen.member.service.dto;
 
-import com.samhap.kokomen.member.domain.Member;
+import java.util.List;
 
 public record RankingResponse(
         Long id,
@@ -8,7 +8,18 @@ public record RankingResponse(
         Integer score,
         Integer interviewCount
 ) {
-    public RankingResponse(Member member, Long interviewCount) {
-        this(member.getId(), member.getNickname(), member.getScore(), interviewCount.intValue());
+    public RankingResponse(RankingProjection rankingProjection) {
+        this(
+                rankingProjection.getId(),
+                rankingProjection.getNickname(),
+                rankingProjection.getScore(),
+                rankingProjection.getInterviewCount().intValue()
+        );
+    }
+
+    public static List<RankingResponse> createRankingResponses(List<RankingProjection> rankingProjections) {
+        return rankingProjections.stream()
+                .map(RankingResponse::new)
+                .toList();
     }
 }

--- a/src/main/java/com/samhap/kokomen/member/service/dto/RankingResponse.java
+++ b/src/main/java/com/samhap/kokomen/member/service/dto/RankingResponse.java
@@ -1,0 +1,14 @@
+package com.samhap.kokomen.member.service.dto;
+
+import com.samhap.kokomen.member.domain.Member;
+
+public record RankingResponse(
+        Long id,
+        String nickname,
+        Integer score,
+        Integer interviewCount
+) {
+    public RankingResponse(Member member, Long interviewCount) {
+        this(member.getId(), member.getNickname(), member.getScore(), interviewCount.intValue());
+    }
+}

--- a/src/main/resources/db/migration/V7__create_index_member_score.sql
+++ b/src/main/resources/db/migration/V7__create_index_member_score.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_member_score ON member (score);

--- a/src/test/java/com/samhap/kokomen/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/member/controller/MemberControllerTest.java
@@ -18,6 +18,7 @@ import com.samhap.kokomen.global.BaseControllerTest;
 import com.samhap.kokomen.global.fixture.interview.InterviewFixtureBuilder;
 import com.samhap.kokomen.global.fixture.interview.RootQuestionFixtureBuilder;
 import com.samhap.kokomen.global.fixture.member.MemberFixtureBuilder;
+import com.samhap.kokomen.interview.domain.InterviewState;
 import com.samhap.kokomen.interview.domain.RootQuestion;
 import com.samhap.kokomen.interview.repository.InterviewRepository;
 import com.samhap.kokomen.interview.repository.RootQuestionRepository;
@@ -151,9 +152,9 @@ class MemberControllerTest extends BaseControllerTest {
 
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
 
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member3).rootQuestion(rootQuestion).build());
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member3).rootQuestion(rootQuestion).build());
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member2).rootQuestion(rootQuestion).build());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member3).rootQuestion(rootQuestion).interviewState(InterviewState.FINISHED).build());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member3).rootQuestion(rootQuestion).interviewState(InterviewState.FINISHED).build());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member2).rootQuestion(rootQuestion).interviewState(InterviewState.FINISHED).build());
 
         String responseJson = """
                 [
@@ -161,13 +162,13 @@ class MemberControllerTest extends BaseControllerTest {
                     "id": %d,
                     "nickname": "300점 회원",
                     "score": 300,
-                    "interview_count": 2
+                    "finished_interview_count": 2
                   },
                   {
                     "id": %d,
                     "nickname": "200점 회원",
                     "score": 200,
-                    "interview_count": 1
+                    "finished_interview_count": 1
                   }
                 ]
                 """.formatted(member3.getId(), member2.getId());
@@ -187,7 +188,7 @@ class MemberControllerTest extends BaseControllerTest {
                                 fieldWithPath("[].id").description("회원 ID"),
                                 fieldWithPath("[].nickname").description("회원 닉네임"),
                                 fieldWithPath("[].score").description("회원 점수"),
-                                fieldWithPath("[].interview_count").description("회원의 인터뷰 수")
+                                fieldWithPath("[].finished_interview_count").description("회원의 완료한 인터뷰 수")
                         )
                 ));
     }

--- a/src/test/java/com/samhap/kokomen/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/member/controller/MemberControllerTest.java
@@ -155,11 +155,29 @@ class MemberControllerTest extends BaseControllerTest {
         interviewRepository.save(InterviewFixtureBuilder.builder().member(member3).rootQuestion(rootQuestion).build());
         interviewRepository.save(InterviewFixtureBuilder.builder().member(member2).rootQuestion(rootQuestion).build());
 
+        String responseJson = """
+                [
+                  {
+                    "id": %d,
+                    "nickname": "300점 회원",
+                    "score": 300,
+                    "interview_count": 2
+                  },
+                  {
+                    "id": %d,
+                    "nickname": "200점 회원",
+                    "score": 200,
+                    "interview_count": 1
+                  }
+                ]
+                """.formatted(member3.getId(), member2.getId());
+
         // when & then
         mockMvc.perform(get("/api/v1/members/ranking")
                         .param("page", "0")
                         .param("size", "2"))
                 .andExpect(status().isOk())
+                .andExpect(content().json(responseJson))
                 .andDo(document("member-findRanking",
                         queryParameters(
                                 parameterWithName("page").description("페이지 번호 (0부터 시작)"),

--- a/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
@@ -4,10 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.samhap.kokomen.global.BaseTest;
+import com.samhap.kokomen.global.fixture.interview.InterviewFixtureBuilder;
+import com.samhap.kokomen.global.fixture.interview.RootQuestionFixtureBuilder;
 import com.samhap.kokomen.global.fixture.member.MemberFixtureBuilder;
+import com.samhap.kokomen.interview.domain.RootQuestion;
+import com.samhap.kokomen.interview.repository.InterviewRepository;
+import com.samhap.kokomen.interview.repository.RootQuestionRepository;
 import com.samhap.kokomen.member.domain.Member;
+import com.samhap.kokomen.member.service.dto.RankingResponse;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -18,6 +28,10 @@ class MemberRepositoryTest extends BaseTest {
     private PlatformTransactionManager transactionManager;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private InterviewRepository interviewRepository;
+    @Autowired
+    private RootQuestionRepository rootQuestionRepository;
 
     @Test
     void free_token_count를_1_감소시킨다() {
@@ -68,5 +82,29 @@ class MemberRepositoryTest extends BaseTest {
                 () -> assertThat(memberRepository.findById(member.getId()).get().getFreeTokenCount()).isEqualTo(Member.DAILY_FREE_TOKEN_COUNT),
                 () -> assertThat(affectedRows).isEqualTo(1)
         );
+    }
+
+    @Test
+    void 총_인터뷰_수와_함께_랭킹을_조회한다() {
+        // given
+        Member member1 = memberRepository.save(MemberFixtureBuilder.builder().nickname("member1").score(200).kakaoId(1L).build());
+        Member member2 = memberRepository.save(MemberFixtureBuilder.builder().nickname("member2").score(300).kakaoId(2L).build());
+        Member member3 = memberRepository.save(MemberFixtureBuilder.builder().nickname("member3").score(100).kakaoId(3L).build());
+
+        RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
+
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member1).rootQuestion(rootQuestion).build());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member2).rootQuestion(rootQuestion).build());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member2).rootQuestion(rootQuestion).build());
+
+        Pageable pageable = PageRequest.of(0, 2, Sort.by("score").descending());
+
+        // when
+        List<RankingResponse> rankings = memberRepository.findRankings(pageable);
+
+        // then
+        assertThat(rankings).hasSize(2);
+        assertThat(rankings).extracting("nickname").containsExactly("member2", "member1");
+        assertThat(rankings).extracting("interviewCount").containsExactly(2, 1);
     }
 }

--- a/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
@@ -7,6 +7,7 @@ import com.samhap.kokomen.global.BaseTest;
 import com.samhap.kokomen.global.fixture.interview.InterviewFixtureBuilder;
 import com.samhap.kokomen.global.fixture.interview.RootQuestionFixtureBuilder;
 import com.samhap.kokomen.global.fixture.member.MemberFixtureBuilder;
+import com.samhap.kokomen.interview.domain.InterviewState;
 import com.samhap.kokomen.interview.domain.RootQuestion;
 import com.samhap.kokomen.interview.repository.InterviewRepository;
 import com.samhap.kokomen.interview.repository.RootQuestionRepository;
@@ -82,7 +83,7 @@ class MemberRepositoryTest extends BaseTest {
     }
 
     @Test
-    void 총_인터뷰_수와_함께_랭킹을_조회한다() {
+    void 완료한_총_인터뷰_수와_함께_랭킹을_조회한다() {
         // given
         Member member200 = memberRepository.save(MemberFixtureBuilder.builder().nickname("200점 회원").score(200).kakaoId(1L).build());
         Member member300 = memberRepository.save(MemberFixtureBuilder.builder().nickname("300점 회원").score(300).kakaoId(2L).build());
@@ -91,9 +92,14 @@ class MemberRepositoryTest extends BaseTest {
 
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
 
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member200).rootQuestion(rootQuestion).build());
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member300).rootQuestion(rootQuestion).build());
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member300).rootQuestion(rootQuestion).build());
+        interviewRepository.save(
+                InterviewFixtureBuilder.builder().member(member200).rootQuestion(rootQuestion).interviewState(InterviewState.FINISHED).build());
+        interviewRepository.save(
+                InterviewFixtureBuilder.builder().member(member300).rootQuestion(rootQuestion).interviewState(InterviewState.FINISHED).build());
+        interviewRepository.save(
+                InterviewFixtureBuilder.builder().member(member300).rootQuestion(rootQuestion).interviewState(InterviewState.FINISHED).build());
+        interviewRepository.save(
+                InterviewFixtureBuilder.builder().member(member300).rootQuestion(rootQuestion).interviewState(InterviewState.IN_PROGRESS).build());
 
         // when
         List<RankingProjection> rankingProjections = memberRepository.findRankings(2, 1);
@@ -101,6 +107,6 @@ class MemberRepositoryTest extends BaseTest {
         // then
         assertThat(rankingProjections).hasSize(2);
         assertThat(rankingProjections).extracting(RankingProjection::getNickname).containsExactly(member300.getNickname(), member200.getNickname());
-        assertThat(rankingProjections).extracting(RankingProjection::getInterviewCount).containsExactly(2L, 1L);
+        assertThat(rankingProjections).extracting(RankingProjection::getFinishedInterviewCount).containsExactly(2L, 1L);
     }
 }

--- a/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
@@ -11,13 +11,10 @@ import com.samhap.kokomen.interview.domain.RootQuestion;
 import com.samhap.kokomen.interview.repository.InterviewRepository;
 import com.samhap.kokomen.interview.repository.RootQuestionRepository;
 import com.samhap.kokomen.member.domain.Member;
-import com.samhap.kokomen.member.service.dto.RankingResponse;
+import com.samhap.kokomen.member.service.dto.RankingProjection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -87,24 +84,23 @@ class MemberRepositoryTest extends BaseTest {
     @Test
     void 총_인터뷰_수와_함께_랭킹을_조회한다() {
         // given
-        Member member1 = memberRepository.save(MemberFixtureBuilder.builder().nickname("member1").score(200).kakaoId(1L).build());
-        Member member2 = memberRepository.save(MemberFixtureBuilder.builder().nickname("member2").score(300).kakaoId(2L).build());
-        Member member3 = memberRepository.save(MemberFixtureBuilder.builder().nickname("member3").score(100).kakaoId(3L).build());
+        Member member200 = memberRepository.save(MemberFixtureBuilder.builder().nickname("200점 회원").score(200).kakaoId(1L).build());
+        Member member300 = memberRepository.save(MemberFixtureBuilder.builder().nickname("300점 회원").score(300).kakaoId(2L).build());
+        memberRepository.save(MemberFixtureBuilder.builder().nickname("100점 회원").score(100).kakaoId(3L).build());
+        memberRepository.save(MemberFixtureBuilder.builder().nickname("400점 회원").score(400).kakaoId(4L).build());
 
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
 
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member1).rootQuestion(rootQuestion).build());
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member2).rootQuestion(rootQuestion).build());
-        interviewRepository.save(InterviewFixtureBuilder.builder().member(member2).rootQuestion(rootQuestion).build());
-
-        Pageable pageable = PageRequest.of(0, 2, Sort.by("score").descending());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member200).rootQuestion(rootQuestion).build());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member300).rootQuestion(rootQuestion).build());
+        interviewRepository.save(InterviewFixtureBuilder.builder().member(member300).rootQuestion(rootQuestion).build());
 
         // when
-        List<RankingResponse> rankings = memberRepository.findRankings(pageable);
+        List<RankingProjection> rankingProjections = memberRepository.findRankings(2, 1);
 
         // then
-        assertThat(rankings).hasSize(2);
-        assertThat(rankings).extracting("nickname").containsExactly("member2", "member1");
-        assertThat(rankings).extracting("interviewCount").containsExactly(2, 1);
+        assertThat(rankingProjections).hasSize(2);
+        assertThat(rankingProjections).extracting(RankingProjection::getNickname).containsExactly(member300.getNickname(), member200.getNickname());
+        assertThat(rankingProjections).extracting(RankingProjection::getInterviewCount).containsExactly(2L, 1L);
     }
 }


### PR DESCRIPTION
# 작업 내용
- 랭킹 조회 API 구현
  - 기획 단계에서 얘기했던, 완료한 인터뷰 수도 응답에 포함시켰습니다.

# 스크린샷
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/ee33f2f9-d9ce-4818-8b1e-c5c212645d3d" />


# 참고 사항
- 드라이빙 테이블 크기를 줄이면서 score 기준 인덱스를 타게 만드려다 보니 FROM 절에 서브쿼리를 쓰게 됐고, JPQL이 FROM 절에 대한 서브쿼리를 지원하지 않아서 native query를 활용하게 됐습니다.
- 당장은 랭커에 대해서만 현재까지 완료한 인터뷰 수를 조회하기 때문에 반정규화를 하지 않았지만, 마이페이지에도 충분히 완료한 인터뷰 수나 진행 중인 인터뷰 수 같은게 표시되면 좋을 것 같아서, 표시하는 방향으로 의견이 모아지면 이것도 반정규화 하는게 좋으려나 싶네요.
  - 완료한 인터뷰 수, 진행 중인 인터뷰 수를 반정규화 하면, 랭킹 조회 시 쿼리가 매우 간단해집니다. 지금은 JOIN에 GROUP BY에 난리도 아니네요.
