### PR TITLE
[Feat] - Interview 조회수 count 기능 구현

### DIFF
--- a/docker/prod/nginx/nginx.conf
+++ b/docker/prod/nginx/nginx.conf
@@ -5,6 +5,11 @@ http {
 
     server {
         listen 80;
+
+        set_real_ip_from 10.0.0.0/16;
+        real_ip_header X-Forwarded-For;
+        real_ip_recursive on;
+
         server_name api.kokomen.kr;
         server_tokens off;
 

--- a/src/main/java/com/samhap/kokomen/global/annotation/Authentication.java
+++ b/src/main/java/com/samhap/kokomen/global/annotation/Authentication.java
@@ -1,0 +1,12 @@
+package com.samhap.kokomen.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authentication {
+    boolean required() default true;
+}

--- a/src/main/java/com/samhap/kokomen/global/config/WebConfig.java
+++ b/src/main/java/com/samhap/kokomen/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.samhap.kokomen.global.config;
 
+import com.samhap.kokomen.global.infrastructure.ClientIpArgumentResolver;
 import com.samhap.kokomen.global.infrastructure.MemberAuthArgumentResolver;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new MemberAuthArgumentResolver());
+        resolvers.addAll(List.of(
+                new MemberAuthArgumentResolver(),
+                new ClientIpArgumentResolver()
+        ));
     }
 }

--- a/src/main/java/com/samhap/kokomen/global/dto/ClientIp.java
+++ b/src/main/java/com/samhap/kokomen/global/dto/ClientIp.java
@@ -1,0 +1,6 @@
+package com.samhap.kokomen.global.dto;
+
+public record ClientIp(
+        String address
+) {
+}

--- a/src/main/java/com/samhap/kokomen/global/dto/MemberAuth.java
+++ b/src/main/java/com/samhap/kokomen/global/dto/MemberAuth.java
@@ -4,6 +4,12 @@ public record MemberAuth(
         Long memberId
 ) {
 
+    private static final MemberAuth NOT_AUTHENTICATED = new MemberAuth(null);
+
+    public static MemberAuth notAuthenticated() {
+        return NOT_AUTHENTICATED;
+    }
+
     public boolean isAuthenticated() {
         return memberId != null;
     }

--- a/src/main/java/com/samhap/kokomen/global/dto/MemberAuth.java
+++ b/src/main/java/com/samhap/kokomen/global/dto/MemberAuth.java
@@ -3,4 +3,8 @@ package com.samhap.kokomen.global.dto;
 public record MemberAuth(
         Long memberId
 ) {
+
+    public boolean isAuthenticated() {
+        return memberId != null;
+    }
 }

--- a/src/main/java/com/samhap/kokomen/global/infrastructure/ClientIpArgumentResolver.java
+++ b/src/main/java/com/samhap/kokomen/global/infrastructure/ClientIpArgumentResolver.java
@@ -2,6 +2,7 @@ package com.samhap.kokomen.global.infrastructure;
 
 import com.samhap.kokomen.global.dto.ClientIp;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 public class ClientIpArgumentResolver implements HandlerMethodArgumentResolver {
 
+    private static final String UNKNOWN_IP_ADDRESS = "0.0.0.0";
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.getParameterType().equals(ClientIp.class);
@@ -25,7 +28,7 @@ public class ClientIpArgumentResolver implements HandlerMethodArgumentResolver {
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-        // TODO: nginx에서 X-Real-IP 헤더를 내려주지 않는 경우를 대비해야 하는지
-        return new ClientIp(request.getHeader("X-Real-IP"));
+        String ipAddress = Objects.requireNonNullElse(request.getHeader("X-Real-IP"), UNKNOWN_IP_ADDRESS);
+        return new ClientIp(ipAddress);
     }
 }

--- a/src/main/java/com/samhap/kokomen/global/infrastructure/ClientIpArgumentResolver.java
+++ b/src/main/java/com/samhap/kokomen/global/infrastructure/ClientIpArgumentResolver.java
@@ -1,0 +1,31 @@
+package com.samhap.kokomen.global.infrastructure;
+
+import com.samhap.kokomen.global.dto.ClientIp;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@Component
+public class ClientIpArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(ClientIp.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        // TODO: nginx에서 X-Real-IP 헤더를 내려주지 않는 경우를 대비해야 하는지
+        return new ClientIp(request.getHeader("X-Real-IP"));
+    }
+}

--- a/src/main/java/com/samhap/kokomen/global/infrastructure/MemberAuthArgumentResolver.java
+++ b/src/main/java/com/samhap/kokomen/global/infrastructure/MemberAuthArgumentResolver.java
@@ -1,9 +1,11 @@
 package com.samhap.kokomen.global.infrastructure;
 
+import com.samhap.kokomen.global.annotation.Authentication;
 import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.global.exception.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -11,6 +13,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Slf4j
 @Component
 public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -24,18 +27,36 @@ public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = parameter.getParameterAnnotation(Authentication.class);
+        if (authentication == null) {
+            throw new IllegalStateException("MemberAuth 파라미터는 @Authentication 어노테이션이 있어야 합니다.");
+        }
+        boolean authenticationRequired = authentication.required();
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-
         HttpSession session = request.getSession(false);
-        if (session == null) {
-            throw new UnauthorizedException("로그인이 필요합니다");
-        }
 
-        Long memberId = (Long) session.getAttribute("MEMBER_ID");
-        if (memberId == null) {
-            throw new IllegalStateException("세션에 MEMBER_ID가 없습니다.");
+        validateAuthentication(session, authenticationRequired);
+        if (session == null) {
+            return new MemberAuth(null);
         }
+        Long memberId = (Long) session.getAttribute("MEMBER_ID");
+        validateAuthentication(memberId, authenticationRequired);
 
         return new MemberAuth(memberId);
+    }
+
+    private void validateAuthentication(HttpSession session, boolean authenticationRequired) {
+        if (session == null && authenticationRequired) {
+            throw new UnauthorizedException("로그인이 필요합니다");
+        }
+    }
+
+    private void validateAuthentication(Long memberId, boolean authenticationRequired) {
+        if (memberId == null) {
+            log.error("세션에 MEMBER_ID가 없습니다.");
+        }
+        if (memberId == null && authenticationRequired) {
+            throw new IllegalStateException("세션에 MEMBER_ID가 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/samhap/kokomen/global/infrastructure/MemberAuthArgumentResolver.java
+++ b/src/main/java/com/samhap/kokomen/global/infrastructure/MemberAuthArgumentResolver.java
@@ -37,7 +37,7 @@ public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver
 
         validateAuthentication(session, authenticationRequired);
         if (session == null) {
-            return new MemberAuth(null);
+            return MemberAuth.notAuthenticated();
         }
         Long memberId = (Long) session.getAttribute("MEMBER_ID");
         validateAuthentication(memberId, authenticationRequired);

--- a/src/main/java/com/samhap/kokomen/global/service/RedisService.java
+++ b/src/main/java/com/samhap/kokomen/global/service/RedisService.java
@@ -9,16 +9,31 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class RedisDistributedLockService {
+public class RedisService {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
     public boolean acquireLock(String lockKey, Duration ttl) {
-        Boolean result = redisTemplate.opsForValue().setIfAbsent(lockKey, "1", ttl);
+        return setIfAbsent(lockKey, "1", ttl);
+    }
+
+    public boolean setIfAbsent(String lockKey, String value, Duration ttl) {
+        Boolean result = redisTemplate.opsForValue().setIfAbsent(lockKey, value, ttl);
         if (result == null) {
             throw new IllegalStateException("분산 락 획득 실패. key: " + lockKey);
         }
         return result;
+    }
+
+    public void incrementKey(String key) {
+        Long count = redisTemplate.opsForValue().increment(key, 1);
+        if (count == null) {
+            throw new IllegalStateException("Redis 카운트 증가 실패. key: " + key);
+        }
+    }
+
+    public void expireKey(String key, Duration ttl) {
+        redisTemplate.expire(key, ttl);
     }
 
     public void releaseLock(String lockKey) {

--- a/src/main/java/com/samhap/kokomen/global/service/RedisService.java
+++ b/src/main/java/com/samhap/kokomen/global/service/RedisService.java
@@ -18,11 +18,11 @@ public class RedisService {
     }
 
     public boolean setIfAbsent(String lockKey, String value, Duration ttl) {
-        Boolean result = redisTemplate.opsForValue().setIfAbsent(lockKey, value, ttl);
-        if (result == null) {
+        Boolean setSuccess = redisTemplate.opsForValue().setIfAbsent(lockKey, value, ttl);
+        if (setSuccess == null) {
             throw new IllegalStateException("분산 락 획득 실패. key: " + lockKey);
         }
-        return result;
+        return setSuccess;
     }
 
     public void incrementKey(String key) {
@@ -32,8 +32,13 @@ public class RedisService {
         }
     }
 
-    public void expireKey(String key, Duration ttl) {
-        redisTemplate.expire(key, ttl);
+    public boolean expireKey(String key, Duration ttl) {
+        Boolean expireSuccess = redisTemplate.expire(key, ttl);
+        if (expireSuccess == null) {
+            throw new IllegalStateException("Redis 키 만료 설정 실패. key: " + key);
+        }
+
+        return expireSuccess;
     }
 
     public void releaseLock(String lockKey) {

--- a/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
+++ b/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
@@ -1,5 +1,6 @@
 package com.samhap.kokomen.interview.controller;
 
+import com.samhap.kokomen.global.annotation.Authentication;
 import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.interview.domain.InterviewState;
 import com.samhap.kokomen.interview.service.InterviewService;
@@ -35,7 +36,7 @@ public class InterviewController {
     @PostMapping
     public ResponseEntity<InterviewStartResponse> startInterview(
             @RequestBody InterviewRequest interviewRequest,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         return ResponseEntity.ok(interviewService.startInterview(interviewRequest, memberAuth));
     }
@@ -45,7 +46,7 @@ public class InterviewController {
             @PathVariable Long interviewId,
             @PathVariable Long curQuestionId,
             @RequestBody AnswerRequest answerRequest,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         return interviewService.proceedInterview(interviewId, curQuestionId, answerRequest, memberAuth)
                 .map(ResponseEntity::ok)
@@ -55,14 +56,15 @@ public class InterviewController {
     @GetMapping("/{interviewId}/my-result")
     public ResponseEntity<InterviewResultResponse> findMyResults(
             @PathVariable Long interviewId,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         return ResponseEntity.ok(interviewService.findMyResults(interviewId, memberAuth));
     }
 
     @GetMapping("/{interviewId}/result")
     public ResponseEntity<InterviewResultResponse> findResults(
-            @PathVariable Long interviewId
+            @PathVariable Long interviewId,
+            @Authentication(required = false) MemberAuth memberAuth
     ) {
         return ResponseEntity.ok(interviewService.findResults(interviewId));
     }
@@ -70,7 +72,7 @@ public class InterviewController {
     @PostMapping("/{interviewId}/like")
     public ResponseEntity<Void> likeInterview(
             @PathVariable Long interviewId,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         interviewService.likeInterview(interviewId, memberAuth);
         return ResponseEntity.ok().build();
@@ -79,7 +81,7 @@ public class InterviewController {
     @GetMapping("/{interviewId}")
     public ResponseEntity<InterviewResponse> findInterview(
             @PathVariable Long interviewId,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         return ResponseEntity.ok(interviewService.findInterview(interviewId, memberAuth));
     }
@@ -88,7 +90,7 @@ public class InterviewController {
     public ResponseEntity<List<InterviewSummaryResponse>> findMyInterviews(
             @RequestParam(required = false) InterviewState state,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         return ResponseEntity.ok(interviewService.findMyInterviews(memberAuth, state, pageable));
     }
@@ -96,7 +98,7 @@ public class InterviewController {
     @DeleteMapping("/{interviewId}/like")
     public ResponseEntity<Void> unlikeInterview(
             @PathVariable Long interviewId,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         interviewService.unlikeInterview(interviewId, memberAuth);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
+++ b/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
@@ -1,6 +1,7 @@
 package com.samhap.kokomen.interview.controller;
 
 import com.samhap.kokomen.global.annotation.Authentication;
+import com.samhap.kokomen.global.dto.ClientIp;
 import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.interview.domain.InterviewState;
 import com.samhap.kokomen.interview.service.InterviewService;
@@ -64,9 +65,10 @@ public class InterviewController {
     @GetMapping("/{interviewId}/result")
     public ResponseEntity<InterviewResultResponse> findResults(
             @PathVariable Long interviewId,
-            @Authentication(required = false) MemberAuth memberAuth
+            @Authentication(required = false) MemberAuth memberAuth,
+            ClientIp clientIp
     ) {
-        return ResponseEntity.ok(interviewService.findResults(interviewId));
+        return ResponseEntity.ok(interviewService.findResults(interviewId, memberAuth, clientIp));
     }
 
     @PostMapping("/{interviewId}/like")

--- a/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/Interview.java
@@ -58,10 +58,10 @@ public class Interview extends BaseEntity {
     private Integer totalScore;
 
     @Column(name = "like_count", nullable = false)
-    private Integer likeCount;
+    private Long likeCount;
 
     @Column(name = "view_count", nullable = false)
-    private Integer viewCount;
+    private Long viewCount;
 
     public Interview(
             Long id,
@@ -71,8 +71,8 @@ public class Interview extends BaseEntity {
             InterviewState interviewState,
             String totalFeedback,
             Integer totalScore,
-            Integer likeCount,
-            Integer viewCount
+            Long likeCount,
+            Long viewCount
     ) {
         validateMaxQuestionCount(maxQuestionCount);
         this.id = id;
@@ -87,7 +87,7 @@ public class Interview extends BaseEntity {
     }
 
     public Interview(Member member, RootQuestion rootQuestion, Integer maxQuestionCount) {
-        this(null, member, rootQuestion, maxQuestionCount, InterviewState.IN_PROGRESS, null, null, 0, 0);
+        this(null, member, rootQuestion, maxQuestionCount, InterviewState.IN_PROGRESS, null, null, 0L, 0L);
     }
 
     private void validateMaxQuestionCount(Integer maxQuestionCount) {

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -189,10 +189,11 @@ public class InterviewService {
             return;
         }
 
-        // TODO: PR에서 expire 먼저 하는 이유 설명하기 -> setIfAbsent가 성공하자마자 만료되는 경우를 방지하기 위함
         String viewCountKey = INTERVIEW_VIEW_COUNT_KEY_FORMAT.formatted(interview.getId());
-        redisService.expireKey(viewCountKey, Duration.ofDays(2));
-        redisService.setIfAbsent(viewCountKey, String.valueOf(interview.getViewCount()), Duration.ofDays(2));
+        boolean expireSuccess = redisService.expireKey(viewCountKey, Duration.ofDays(2));
+        if (!expireSuccess) {
+            redisService.setIfAbsent(viewCountKey, String.valueOf(interview.getViewCount()), Duration.ofDays(2));
+        }
         redisService.incrementKey(viewCountKey);
     }
 

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -1,10 +1,11 @@
 package com.samhap.kokomen.interview.service;
 
+import com.samhap.kokomen.global.dto.ClientIp;
 import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.global.exception.BadRequestException;
 import com.samhap.kokomen.global.exception.ForbiddenException;
 import com.samhap.kokomen.global.exception.UnauthorizedException;
-import com.samhap.kokomen.global.service.RedisDistributedLockService;
+import com.samhap.kokomen.global.service.RedisService;
 import com.samhap.kokomen.interview.domain.Answer;
 import com.samhap.kokomen.interview.domain.Interview;
 import com.samhap.kokomen.interview.domain.InterviewLike;
@@ -43,6 +44,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class InterviewService {
 
     private static final int EXCLUDED_RECENT_ROOT_QUESTION_COUNT = 50;
+    public static final String INTERVIEW_VIEW_COUNT_LOCK_KEY_FORMAT = "interview:viewCount:%s:%s";
+    public static final String INTERVIEW_VIEW_COUNT_KEY_FORMAT = "interview:viewCount:%s";
 
     private final GptClient gptClient;
     private final BedrockClient bedrockClient;
@@ -51,7 +54,7 @@ public class InterviewService {
     private final AnswerRepository answerRepository;
     private final MemberRepository memberRepository;
     private final RootQuestionRepository rootQuestionRepository;
-    private final RedisDistributedLockService redisDistributedLockService;
+    private final RedisService redisService;
     private final InterviewAnswerResponseService interviewAnswerResponseService;
     private final InterviewLikeRepository interviewLikeRepository;
 
@@ -84,10 +87,10 @@ public class InterviewService {
 
     // TODO: answer가 question을 들고 있는데, 영속성 컨텍스트를 활용해서 가져오는지 -> lazy 관련해서
     public Optional<InterviewProceedResponse> proceedInterview(Long interviewId, Long curQuestionId, AnswerRequest answerRequest, MemberAuth memberAuth) {
-        String lockKey = "interview:proceed:" + memberAuth.memberId();
-        acquireLock(lockKey);
-
         Member member = readMember(memberAuth.memberId());
+        String lockKey = "interview:proceed:" + member.getId();
+        acquireLockForProceedInterview(lockKey);
+
         validateHasToken(member);
         Interview interview = readInterview(interviewId);
         validateInterviewee(interview, member);
@@ -97,12 +100,12 @@ public class InterviewService {
             LlmResponse llmResponse = bedrockClient.requestToBedrock(questionAndAnswers);
             return interviewAnswerResponseService.handleGptResponse(member.getId(), questionAndAnswers, llmResponse, interview.getId());
         } finally {
-            redisDistributedLockService.releaseLock(lockKey);
+            redisService.releaseLock(lockKey);
         }
     }
 
-    private void acquireLock(String lockKey) {
-        boolean lockAcquired = redisDistributedLockService.acquireLock(lockKey, Duration.ofSeconds(30));
+    private void acquireLockForProceedInterview(String lockKey) {
+        boolean lockAcquired = redisService.acquireLock(lockKey, Duration.ofSeconds(30));
         if (!lockAcquired) {
             throw new BadRequestException("이미 처리 중인 답변이 있습니다. 잠시 후 다시 시도해주세요.");
         }
@@ -157,11 +160,15 @@ public class InterviewService {
     }
 
     @Transactional(readOnly = true)
-    public InterviewResultResponse findResults(Long interviewId) {
+    public InterviewResultResponse findResults(Long interviewId, MemberAuth memberAuth, ClientIp clientIp) {
         Interview interview = readInterview(interviewId);
         validateInterviewFinished(interview);
         List<Answer> answers = answerRepository.findByQuestionIn(questionRepository.findByInterview(interview));
         List<FeedbackResponse> feedbackResponses = FeedbackResponse.from(answers);
+
+        if (!isInterviewee(memberAuth, interview)) {
+            increaseViewCount(interview, clientIp);
+        }
 
         return InterviewResultResponse.createResultResponse(feedbackResponses, interview);
     }
@@ -170,6 +177,23 @@ public class InterviewService {
         if (interview.isInProgress()) {
             throw new BadRequestException("해당 인터뷰는 아직 진행 중입니다. 인터뷰가 종료된 후 결과를 조회할 수 있습니다.");
         }
+    }
+
+    private boolean isInterviewee(MemberAuth memberAuth, Interview interview) {
+        return memberAuth.isAuthenticated() && interview.isInterviewee(readMember(memberAuth.memberId()));
+    }
+
+    private void increaseViewCount(Interview interview, ClientIp clientIp) {
+        String viewCountLockKey = INTERVIEW_VIEW_COUNT_LOCK_KEY_FORMAT.formatted(interview.getId(), clientIp.address());
+        if (!redisService.acquireLock(viewCountLockKey, Duration.ofDays(1))) {
+            return;
+        }
+
+        // TODO: PR에서 expire 먼저 하는 이유 설명하기 -> setIfAbsent가 성공하자마자 만료되는 경우를 방지하기 위함
+        String viewCountKey = INTERVIEW_VIEW_COUNT_KEY_FORMAT.formatted(interview.getId());
+        redisService.expireKey(viewCountKey, Duration.ofDays(2));
+        redisService.setIfAbsent(viewCountKey, String.valueOf(interview.getViewCount()), Duration.ofDays(2));
+        redisService.incrementKey(viewCountKey);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -44,7 +44,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class InterviewService {
 
     private static final int EXCLUDED_RECENT_ROOT_QUESTION_COUNT = 50;
-    public static final String INTERVIEW_VIEW_COUNT_LOCK_KEY_FORMAT = "interview:viewCount:%s:%s";
+    private static final String INTERVIEW_PROCEED_LOCK_KEY_FORMAT = "lock:interview:proceed:%s";
+    public static final String INTERVIEW_VIEW_COUNT_LOCK_KEY_FORMAT = "lock:interview:viewCount:%s:%s";
     public static final String INTERVIEW_VIEW_COUNT_KEY_FORMAT = "interview:viewCount:%s";
 
     private final GptClient gptClient;
@@ -88,7 +89,7 @@ public class InterviewService {
     // TODO: answer가 question을 들고 있는데, 영속성 컨텍스트를 활용해서 가져오는지 -> lazy 관련해서
     public Optional<InterviewProceedResponse> proceedInterview(Long interviewId, Long curQuestionId, AnswerRequest answerRequest, MemberAuth memberAuth) {
         Member member = readMember(memberAuth.memberId());
-        String lockKey = "interview:proceed:" + member.getId();
+        String lockKey = INTERVIEW_PROCEED_LOCK_KEY_FORMAT.formatted(member.getId());
         acquireLockForProceedInterview(lockKey);
 
         validateHasToken(member);

--- a/src/main/java/com/samhap/kokomen/member/controller/MemberController.java
+++ b/src/main/java/com/samhap/kokomen/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.samhap.kokomen.member.controller;
 
+import com.samhap.kokomen.global.annotation.Authentication;
 import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.member.service.MemberService;
 import com.samhap.kokomen.member.service.dto.MyProfileResponse;
@@ -27,7 +28,7 @@ public class MemberController {
 
     @GetMapping("/me/profile")
     public ResponseEntity<MyProfileResponse> findMyProfile(
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         return ResponseEntity.ok(memberService.findMember(memberAuth));
     }
@@ -35,7 +36,7 @@ public class MemberController {
     @PatchMapping("/me/profile")
     public ResponseEntity<Void> updateProfile(
             @Valid @RequestBody ProfileUpdateRequest profileUpdateRequest,
-            MemberAuth memberAuth
+            @Authentication MemberAuth memberAuth
     ) {
         memberService.updateProfile(memberAuth, profileUpdateRequest);
         return ResponseEntity.ok().build();

--- a/src/main/resources/db/migration/V9__modify_like_count_view_count_to_bigint.sql
+++ b/src/main/resources/db/migration/V9__modify_like_count_view_count_to_bigint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE interview MODIFY COLUMN like_count BIGINT;
+
+ALTER TABLE interview MODIFY COLUMN view_count BIGINT;

--- a/src/test/java/com/samhap/kokomen/KokomenApplicationTests.java
+++ b/src/test/java/com/samhap/kokomen/KokomenApplicationTests.java
@@ -1,10 +1,9 @@
 package com.samhap.kokomen;
 
+import com.samhap.kokomen.global.BaseTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-class KokomenApplicationTests {
+class KokomenApplicationTests extends BaseTest {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/samhap/kokomen/global/fixture/interview/InterviewFixtureBuilder.java
+++ b/src/test/java/com/samhap/kokomen/global/fixture/interview/InterviewFixtureBuilder.java
@@ -15,8 +15,8 @@ public class InterviewFixtureBuilder {
     private InterviewState interviewState;
     private String totalFeedback;
     private Integer totalScore;
-    private Integer likeCount;
-    private Integer viewCount;
+    private Long likeCount;
+    private Long viewCount;
 
     public static InterviewFixtureBuilder builder() {
         return new InterviewFixtureBuilder();
@@ -57,12 +57,12 @@ public class InterviewFixtureBuilder {
         return this;
     }
 
-    public InterviewFixtureBuilder likeCount(Integer likeCount) {
+    public InterviewFixtureBuilder likeCount(Long likeCount) {
         this.likeCount = likeCount;
         return this;
     }
 
-    public InterviewFixtureBuilder viewCount(Integer viewCount) {
+    public InterviewFixtureBuilder viewCount(Long viewCount) {
         this.viewCount = viewCount;
         return this;
     }
@@ -76,8 +76,8 @@ public class InterviewFixtureBuilder {
                 interviewState != null ? interviewState : InterviewState.IN_PROGRESS,
                 totalFeedback,
                 totalScore,
-                likeCount != null ? likeCount : 0,
-                viewCount != null ? viewCount : 0
+                likeCount != null ? likeCount : 0L,
+                viewCount != null ? viewCount : 0L
         );
     }
 

--- a/src/test/java/com/samhap/kokomen/global/service/RedisServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/global/service/RedisServiceTest.java
@@ -8,10 +8,10 @@ import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class RedisDistributedLockServiceTest extends BaseTest {
+class RedisServiceTest extends BaseTest {
 
     @Autowired
-    private RedisDistributedLockService redisDistributedLockService;
+    private RedisService redisService;
 
     @Test
     void 같은_키값에_대해_분산락은_하나만_획득할_수_있다() {
@@ -20,8 +20,8 @@ class RedisDistributedLockServiceTest extends BaseTest {
         Duration ttl = Duration.ofSeconds(10);
 
         // when
-        boolean firstTrial = redisDistributedLockService.acquireLock(lockKey, ttl);
-        boolean secondTrial = redisDistributedLockService.acquireLock(lockKey, ttl);
+        boolean firstTrial = redisService.acquireLock(lockKey, ttl);
+        boolean secondTrial = redisService.acquireLock(lockKey, ttl);
 
         // then
         assertAll(
@@ -37,10 +37,10 @@ class RedisDistributedLockServiceTest extends BaseTest {
         Duration ttl = Duration.ofSeconds(10);
 
         // when
-        boolean firstTrial = redisDistributedLockService.acquireLock(lockKey, ttl);
-        boolean secondTrial = redisDistributedLockService.acquireLock(lockKey, ttl);
-        redisDistributedLockService.releaseLock(lockKey);
-        boolean retrial = redisDistributedLockService.acquireLock(lockKey, ttl);
+        boolean firstTrial = redisService.acquireLock(lockKey, ttl);
+        boolean secondTrial = redisService.acquireLock(lockKey, ttl);
+        redisService.releaseLock(lockKey);
+        boolean retrial = redisService.acquireLock(lockKey, ttl);
 
         // then
         assertAll(

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -663,7 +663,7 @@ class InterviewControllerTest extends BaseControllerTest {
         session.setAttribute("MEMBER_ID", member.getId());
 
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0L).build());
 
         // when & then
         mockMvc.perform(post("/api/v1/interviews/{interview_id}/like", interview.getId())
@@ -688,7 +688,7 @@ class InterviewControllerTest extends BaseControllerTest {
         session.setAttribute("MEMBER_ID", member.getId());
 
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1L).build());
         interviewLikeRepository.save(InterviewLikeFixtureBuilder.builder().interview(interview).member(member).build());
 
         // when & then

--- a/src/test/java/com/samhap/kokomen/interview/repository/InterviewRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/repository/InterviewRepositoryTest.java
@@ -32,7 +32,7 @@ class InterviewRepositoryTest extends BaseTest {
         // given
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0L).build());
 
         // when
         TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
@@ -49,7 +49,7 @@ class InterviewRepositoryTest extends BaseTest {
         // given
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1L).build());
 
         // when
         TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());

--- a/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
@@ -130,7 +130,7 @@ class InterviewServiceTest extends BaseTest {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0L).build());
 
         // when
         interviewService.likeInterview(interview.getId(), new MemberAuth(member.getId()));
@@ -145,7 +145,7 @@ class InterviewServiceTest extends BaseTest {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(0L).build());
         interviewService.likeInterview(interview.getId(), new MemberAuth(member.getId()));
 
         // when & then
@@ -159,7 +159,7 @@ class InterviewServiceTest extends BaseTest {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1L).build());
         interviewService.likeInterview(interview.getId(), new MemberAuth(member.getId()));
 
         // when
@@ -175,7 +175,7 @@ class InterviewServiceTest extends BaseTest {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).likeCount(1L).build());
 
         // when & then
         assertThatThrownBy(() -> interviewService.unlikeInterview(interview.getId(), new MemberAuth(member.getId())))

--- a/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.samhap.kokomen.global.BaseTest;
+import com.samhap.kokomen.global.dto.ClientIp;
 import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.global.exception.BadRequestException;
 import com.samhap.kokomen.global.fixture.interview.AnswerFixtureBuilder;
@@ -33,6 +34,7 @@ import com.samhap.kokomen.member.repository.MemberRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 
 class InterviewServiceTest extends BaseTest {
 
@@ -48,6 +50,8 @@ class InterviewServiceTest extends BaseTest {
     private MemberRepository memberRepository;
     @Autowired
     private RootQuestionRepository rootQuestionRepository;
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
 
     @Test
     void 인터뷰를_진행할_때_마지막_답변이_아니면_다음_꼬리_질문과_현재_답변에_대한_피드백을_응답한다() {
@@ -123,6 +127,91 @@ class InterviewServiceTest extends BaseTest {
                 () -> assertThat(memberRepository.findById(member.getId()).get().getScore()).isEqualTo(member.getScore() + answerRank.getScore() * 3),
                 () -> assertThat(memberRepository.findById(member.getId()).get().getFreeTokenCount()).isEqualTo(member.getFreeTokenCount() - 1)
         );
+    }
+
+    @Test
+    void 다른_사용자의_인터뷰_최종_결과를_조회하면_조회수가_1_증가한다() {
+        // given
+        Member interviewee = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(1L).build());
+        Member otherMember = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).build());
+        RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().content("자바의 특징은 무엇인가요?").build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(interviewee).rootQuestion(rootQuestion).viewCount(0L).build());
+        Question question1 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content(rootQuestion.getContent()).build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question1).content("자바는 객체지향 프로그래밍 언어입니다.").answerRank(AnswerRank.C).feedback("부족합니다.").build());
+        Question question2 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content("객체지향의 특징을 설명해주세요.").build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question2).content("객체가 각자 책임집니다.").answerRank(AnswerRank.D).feedback("부족합니다.").build());
+        Question question3 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content("객체는 무엇인가요?").build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question3).content("클래스의 인스턴스 입니다.").answerRank(AnswerRank.F).feedback("부족합니다.").build());
+        interview.evaluate("제대로 좀 공부 해라.", -30);
+        interviewRepository.save(interview);
+
+        // when
+        interviewService.findResults(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
+
+        // then
+        Long viewCount = Long.valueOf((String) redisTemplate.opsForValue().get(InterviewService.INTERVIEW_VIEW_COUNT_KEY_FORMAT.formatted(interview.getId())));
+        assertThat(viewCount).isEqualTo(1L);
+    }
+
+    @Test
+    void 다른_사용자의_인터뷰_최종_결과를_연속으로_조회해도_조회수는_1만_증가한다() {
+        // given
+        Member interviewee = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(1L).build());
+        Member otherMember = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).build());
+        RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().content("자바의 특징은 무엇인가요?").build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(interviewee).rootQuestion(rootQuestion).viewCount(0L).build());
+        Question question1 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content(rootQuestion.getContent()).build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question1).content("자바는 객체지향 프로그래밍 언어입니다.").answerRank(AnswerRank.C).feedback("부족합니다.").build());
+        Question question2 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content("객체지향의 특징을 설명해주세요.").build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question2).content("객체가 각자 책임집니다.").answerRank(AnswerRank.D).feedback("부족합니다.").build());
+        Question question3 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content("객체는 무엇인가요?").build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question3).content("클래스의 인스턴스 입니다.").answerRank(AnswerRank.F).feedback("부족합니다.").build());
+        interview.evaluate("제대로 좀 공부 해라.", -30);
+        interviewRepository.save(interview);
+
+        // when
+        interviewService.findResults(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
+        interviewService.findResults(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
+        interviewService.findResults(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
+
+        // then
+        Long viewCount = Long.valueOf((String) redisTemplate.opsForValue().get(InterviewService.INTERVIEW_VIEW_COUNT_KEY_FORMAT.formatted(interview.getId())));
+        assertThat(viewCount).isEqualTo(1L);
+    }
+
+    @Test
+    void 자신의_인터뷰_최종_결과를_조회하면_조회수는_증가하지_않는다() {
+        // given
+        Member interviewee = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(1L).build());
+        Member otherMember = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).build());
+        RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().content("자바의 특징은 무엇인가요?").build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(interviewee).rootQuestion(rootQuestion).viewCount(0L).build());
+        Question question1 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content(rootQuestion.getContent()).build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question1).content("자바는 객체지향 프로그래밍 언어입니다.").answerRank(AnswerRank.C).feedback("부족합니다.").build());
+        Question question2 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content("객체지향의 특징을 설명해주세요.").build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question2).content("객체가 각자 책임집니다.").answerRank(AnswerRank.D).feedback("부족합니다.").build());
+        Question question3 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content("객체는 무엇인가요?").build());
+        answerRepository.save(
+                AnswerFixtureBuilder.builder().question(question3).content("클래스의 인스턴스 입니다.").answerRank(AnswerRank.F).feedback("부족합니다.").build());
+        interview.evaluate("제대로 좀 공부 해라.", -30);
+        interviewRepository.save(interview);
+
+        interviewService.findResults(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
+
+        // when
+        interviewService.findResults(interview.getId(), new MemberAuth(interviewee.getId()), new ClientIp("1.1.1.1"));
+
+        // then
+        Long viewCount = Long.valueOf((String) redisTemplate.opsForValue().get(InterviewService.INTERVIEW_VIEW_COUNT_KEY_FORMAT.formatted(interview.getId())));
+        assertThat(viewCount).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
@@ -240,7 +240,7 @@ class InterviewServiceTest extends BaseTest {
         // when
         for (int i = 1; i <= 10; i++) {
             ClientIp clientIp = new ClientIp("%d.%d.%d.%d".formatted(i, i, i, i));
-            executorService.execute(() -> interviewService.findResults(interview.getId(), new MemberAuth(null), clientIp));
+            executorService.execute(() -> interviewService.findResults(interview.getId(), MemberAuth.notAuthenticated(), clientIp));
         }
 
         executorService.shutdown();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -39,6 +39,8 @@ spring:
 ---
 # docs
 spring:
+  flyway:
+    enabled: false
   config:
     activate:
       on-profile: docs
@@ -49,6 +51,6 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create-drop
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
# 작업 내용
- 조회수 카운팅: 인터뷰 조회 시 Redis에 실시간 카운트 기록
- 치팅 방지: 동일 IP에서 같은 인터뷰 조회 시 24시간 내 1회만 카운트되도록 분산 락 적용

# 스크린샷
![image](https://github.com/user-attachments/assets/6ed0c3d3-7db9-4bca-a0d2-5b6fe73c6959)

# 참고 사항
### 추후 구현 예정 기능
- DB 동기화: Redis 조회수 데이터를 주기적으로 DB에 반영
- 조회수 조회: 인터뷰 조회 API에 조회수 정보 추가

### 현재 이슈 및 개선 사항
#### 1. 클라이언트 IP 획득 문제
- 현재 상황: Nginx에서 X-Real-IP 헤더로 클라이언트 IP 전달
- 문제점: SSR 환경에서 클라이언트 서버 측 추가 처리 필요
- 해결 방안: 클라이언트 서버에서 IP 전달 로직 보완 필요

#### 2. Redis 장애 시 조회 성능 영향
- 현재 상황: Redis 실패 또는 지연 시 조회 API 실패 또는 응답 시간 증가 
- 문제점: 조회수 기능이 핵심 조회 성능에 영향
- 개선 방안:
  - 비동기 처리로 조회 API와 분리
  - Redis 타임아웃 설정 및 fallback 처리
  - Circuit Breaker 패턴 적용