### PR TITLE
[Fix] - 트랜잭션 외부에서 Lazy 엔티티 접근 시 발생하는 LazyInitializationException 해결

### DIFF
--- a/src/main/java/com/samhap/kokomen/interview/domain/InterviewMessagesFactory.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/InterviewMessagesFactory.java
@@ -58,10 +58,12 @@ public final class InterviewMessagesFactory {
     }
 
     private static void addBedrockMessages(QuestionAndAnswers questionAndAnswers, List<Message> messages) {
-        questionAndAnswers.getPrevAnswers().forEach(answer -> {
-            messages.add(createBedrockMessage("assistant", answer.getQuestion().getContent()));
-            messages.add(createBedrockMessage("user", answer.getContent()));
-        });
+        List<Question> questions = questionAndAnswers.getQuestions();
+        List<Answer> prevAnswers = questionAndAnswers.getPrevAnswers();
+        for (int i = 0; i < prevAnswers.size(); i++) {
+            messages.add(createBedrockMessage("assistant", questions.get(i).getContent()));
+            messages.add(createBedrockMessage("user", prevAnswers.get(i).getContent()));
+        }
 
         messages.add(createBedrockMessage("assistant", questionAndAnswers.readCurQuestion().getContent()));
         messages.add(createBedrockMessage("user", questionAndAnswers.getCurAnswerContent()));

--- a/src/main/java/com/samhap/kokomen/interview/domain/InterviewMessagesFactory.java
+++ b/src/main/java/com/samhap/kokomen/interview/domain/InterviewMessagesFactory.java
@@ -29,10 +29,12 @@ public final class InterviewMessagesFactory {
     }
 
     private static void addGptMessages(QuestionAndAnswers questionAndAnswers, List<GptMessage> gptMessages) {
-        questionAndAnswers.getPrevAnswers().forEach(answer -> {
-            gptMessages.add(new GptMessage("assistant", answer.getQuestion().getContent()));
-            gptMessages.add(new GptMessage("user", answer.getContent()));
-        });
+        List<Question> questions = questionAndAnswers.getQuestions();
+        List<Answer> prevAnswers = questionAndAnswers.getPrevAnswers();
+        for (int i = 0; i < prevAnswers.size(); i++) {
+            gptMessages.add(new GptMessage("assistant", questions.get(i).getContent()));
+            gptMessages.add(new GptMessage("user", prevAnswers.get(i).getContent()));
+        }
 
         gptMessages.add(new GptMessage("assistant", questionAndAnswers.readCurQuestion().getContent()));
         gptMessages.add(new GptMessage("user", questionAndAnswers.getCurAnswerContent()));


### PR DESCRIPTION
# 작업 내용
- Answer에서 Question의 content에 접근하지 않고, Question에서 접근하도록 변경하여 LazyInitializationException 발생하지 않도록

# 스크린샷

# 참고 사항
- 테스트에서 XxxClient를 mock처리하고 있는데, XxxClient 내부에서 InterviewMessageFactory를 호출하고 있어서 예상치 못한 예외가 발생한 것 같습니다.
  - mock 처리 범위를 최소화 하는 것이 필요해보이며, 따라서 XxxClient에게 요청할 때 넘겨주는 파라미터로 QuestionAndAnswers가 아닌 request DTO를 넘겨주는 방식으로 다른 이슈에서 리팩토링 진행하겠습니다. 
