### PR TITLE
[Feat] - 남의 인터뷰 목록/결과 조회 시 응답에 닉네임, 등수 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -142,8 +142,6 @@ include::{snippetsDir}/interview-findOtherMemberInterviews-authenticated/curl-re
 ==== 다른 사용자의 완료된 인터뷰 목록 조회 - 비회원 버전
 
 include::{snippetsDir}/interview-findOtherMemberInterviews-unauthenticated/http-request.adoc[]
-include::{snippetsDir}/interview-findOtherMemberInterviews-unauthenticated/http-response.adoc[]
-include::{snippetsDir}/interview-findOtherMemberInterviews-unauthenticated/curl-request.adoc[]
 
 === 자신의 인터뷰 결과 조회
 
@@ -165,27 +163,25 @@ include::{snippetsDir}/interview-findMyResult-exception2/http-response.adoc[]
 
 === 다른 사용자의 완료된 인터뷰 결과 조회 - 로그인 버전
 
-include::{snippetsDir}/interview-findOtherMemberResult-authenticated/http-request.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-authenticated/path-parameters.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-authenticated/http-response.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-authenticated/response-fields.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-authenticated/curl-request.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-authenticated/http-request.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-authenticated/path-parameters.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-authenticated/http-response.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-authenticated/response-fields.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-authenticated/curl-request.adoc[]
 
 ==== 다른 사용자의 완료된 인터뷰 결과 조회 - 비회원 버전
 
-include::{snippetsDir}/interview-findOtherMemberResult-unauthenticated/http-request.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-unauthenticated/http-response.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-unauthenticated/curl-request.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-unauthenticated/http-request.adoc[]
 
 ==== 다른 사용자의 완료된 인터뷰 결과 조회 예외 1
 
-include::{snippetsDir}/interview-findOtherMemberResult-exception1/http-request.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-exception1/http-response.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-exception1/http-request.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-exception1/http-response.adoc[]
 
 ==== 다른 사용자의 완료된 인터뷰 결과 조회 예외 2
 
-include::{snippetsDir}/interview-findOtherMemberResult-exception2/http-request.adoc[]
-include::{snippetsDir}/interview-findOtherMemberResult-exception2/http-response.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-exception2/http-request.adoc[]
+include::{snippetsDir}/interview-findOtherMemberInterviewResult-exception2/http-response.adoc[]
 
 === 인터뷰 좋아요 취소 요청
 

--- a/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
+++ b/src/main/java/com/samhap/kokomen/interview/controller/InterviewController.java
@@ -4,6 +4,7 @@ import com.samhap.kokomen.global.annotation.Authentication;
 import com.samhap.kokomen.global.dto.ClientIp;
 import com.samhap.kokomen.global.dto.MemberAuth;
 import com.samhap.kokomen.interview.domain.InterviewState;
+import com.samhap.kokomen.interview.external.dto.response.InterviewSummaryResponses;
 import com.samhap.kokomen.interview.service.InterviewService;
 import com.samhap.kokomen.interview.service.dto.AnswerRequest;
 import com.samhap.kokomen.interview.service.dto.InterviewRequest;
@@ -81,7 +82,7 @@ public class InterviewController {
     }
 
     @GetMapping
-    public ResponseEntity<List<InterviewSummaryResponse>> findOtherMemberInterviews(
+    public ResponseEntity<InterviewSummaryResponses> findOtherMemberInterviews(
             @RequestParam("member_id") Long memberId,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             @Authentication(required = false) MemberAuth memberAuth

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
@@ -6,10 +6,10 @@ import java.util.List;
 import java.util.Set;
 
 public record InterviewSummaryResponses(
-        String intervieweeNickname,
+        List<InterviewSummaryResponse> interviewSummaries,
         Long totalMemberCount,
         Long intervieweeRank,
-        List<InterviewSummaryResponse> interviewSummaries
+        String intervieweeNickname
 ) {
     public static InterviewSummaryResponses createOfOtherMemberForLoginMember(
             String intervieweeNickname,
@@ -24,10 +24,7 @@ public record InterviewSummaryResponses(
                 .toList();
 
         return new InterviewSummaryResponses(
-                intervieweeNickname,
-                totalMemberCount,
-                intervieweeRank,
-                interviewSummaries
+                interviewSummaries, totalMemberCount, intervieweeRank, intervieweeNickname
         );
     }
 
@@ -42,10 +39,7 @@ public record InterviewSummaryResponses(
                 .toList();
 
         return new InterviewSummaryResponses(
-                intervieweeNickname,
-                totalMemberCount,
-                intervieweeRank,
-                interviewSummaries
+                interviewSummaries, totalMemberCount, intervieweeRank, intervieweeNickname
         );
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
@@ -1,10 +1,51 @@
 package com.samhap.kokomen.interview.external.dto.response;
 
+import com.samhap.kokomen.interview.domain.Interview;
 import com.samhap.kokomen.interview.service.dto.InterviewSummaryResponse;
 import java.util.List;
+import java.util.Set;
 
 public record InterviewSummaryResponses(
         String intervieweeNickname,
-        List<InterviewSummaryResponse> InterviewSummaryResponses
+        Long totalMemberCount,
+        Long intervieweeRank,
+        List<InterviewSummaryResponse> interviewSummaries
 ) {
+    public static InterviewSummaryResponses createOfOtherMemberForLoginMember(
+            String intervieweeNickname,
+            Long totalMemberCount,
+            Long intervieweeRank,
+            List<Interview> interviews,
+            Set<Long> likedInterviewIds
+    ) {
+        List<InterviewSummaryResponse> interviewSummaries = interviews.stream()
+                .map(interview -> InterviewSummaryResponse.createOfOtherMemberForLoginMember(
+                        interview, likedInterviewIds.contains(interview.getId())))
+                .toList();
+
+        return new InterviewSummaryResponses(
+                intervieweeNickname,
+                totalMemberCount,
+                intervieweeRank,
+                interviewSummaries
+        );
+    }
+
+    public static InterviewSummaryResponses createOfOtherMemberForLogoutMember(
+            String intervieweeNickname,
+            Long totalMemberCount,
+            Long intervieweeRank,
+            List<Interview> interviews
+    ) {
+        List<InterviewSummaryResponse> interviewSummaries = interviews.stream()
+                .map(interview -> InterviewSummaryResponse.createOfOtherMemberForLogoutMember(interview))
+                .toList();
+
+        return new InterviewSummaryResponses(
+                intervieweeNickname,
+                totalMemberCount,
+                intervieweeRank,
+                interviewSummaries
+        );
+    }
 }

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
@@ -1,0 +1,10 @@
+package com.samhap.kokomen.interview.external.dto.response;
+
+import com.samhap.kokomen.interview.service.dto.InterviewSummaryResponse;
+import java.util.List;
+
+public record InterviewSummaryResponses(
+        String intervieweeNickname,
+        List<InterviewSummaryResponse> InterviewSummaryResponses
+) {
+}

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/FeedbackResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/FeedbackResponse.java
@@ -28,13 +28,6 @@ public record FeedbackResponse(
         );
     }
 
-    public static List<FeedbackResponse> createForNotAuthenticatedUser(List<Answer> answers) {
-        return answers.stream()
-                .map(answer -> new FeedbackResponse(answer, false))
-                .sorted(Comparator.comparing(FeedbackResponse::questionId))
-                .toList();
-    }
-
     public static List<FeedbackResponse> createMine(List<Answer> answers) {
         return answers.stream()
                 .map(FeedbackResponse::createMine)

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewResultResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewResultResponse.java
@@ -1,8 +1,10 @@
 package com.samhap.kokomen.interview.service.dto;
 
+import com.samhap.kokomen.interview.domain.Answer;
 import com.samhap.kokomen.interview.domain.Interview;
 import com.samhap.kokomen.member.domain.Member;
 import java.util.List;
+import java.util.Set;
 
 public record InterviewResultResponse(
         List<FeedbackResponse> feedbacks,
@@ -10,11 +12,14 @@ public record InterviewResultResponse(
         Integer totalScore,
         Long interviewLikeCount,
         Boolean interviewAlreadyLiked,
+        String intervieweeNickname,
+        Long totalMemberCount,
+        Long intervieweeRank,
         Integer userCurScore,
         Integer userPrevScore
 ) {
 
-    public static InterviewResultResponse createMyResultResponse(
+    public static InterviewResultResponse createMine(
             List<FeedbackResponse> feedbacks,
             Interview interview,
             Member member
@@ -25,22 +30,61 @@ public record InterviewResultResponse(
                 interview.getTotalScore(),
                 null,
                 null,
+                null,
+                null,
+                null,
                 member.getScore(),
                 member.getScore() - interview.getTotalScore()
         );
     }
 
-    public static InterviewResultResponse createResultResponse(
-            List<FeedbackResponse> feedbacks,
+    public static InterviewResultResponse createOfOtherMemberForLoginMember(
+            List<Answer> answers,
+            Set<Long> likedAnswerIds,
             Interview interview,
-            Boolean interviewAlreadyLiked
+            Boolean interviewAlreadyLiked,
+            String intervieweeNickname,
+            Long totalMemberCount,
+            Long intervieweeRank
     ) {
+        List<FeedbackResponse> feedbackResponses = answers.stream()
+                .map(answer -> new FeedbackResponse(answer, likedAnswerIds.contains(answer.getId())))
+                .toList();
+
         return new InterviewResultResponse(
-                feedbacks,
+                feedbackResponses,
                 interview.getTotalFeedback(),
                 interview.getTotalScore(),
                 interview.getLikeCount(),
                 interviewAlreadyLiked,
+                intervieweeNickname,
+                totalMemberCount,
+                intervieweeRank,
+                null,
+                null
+        );
+    }
+
+    public static InterviewResultResponse createOfOtherMemberForLogoutMember(
+            List<Answer> answers,
+            Interview interview,
+            String intervieweeNickname,
+            Long totalMemberCount,
+            Long intervieweeRank
+    ) {
+        List<FeedbackResponse> feedbackResponses = answers.stream()
+                .map(answer -> new FeedbackResponse(answer, false))
+                .toList();
+
+        return new InterviewResultResponse(
+                feedbackResponses,
+                interview.getTotalFeedback(),
+                interview.getTotalScore(),
+                interview.getLikeCount(),
+                false,
+                intervieweeNickname,
+                totalMemberCount,
+                intervieweeRank,
                 null,
                 null
         );

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewSummaryResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewSummaryResponse.java
@@ -2,12 +2,10 @@ package com.samhap.kokomen.interview.service.dto;
 
 import com.samhap.kokomen.category.domain.Category;
 import com.samhap.kokomen.interview.domain.Interview;
-import com.samhap.kokomen.interview.domain.InterviewState;
 import java.time.LocalDateTime;
 
 public record InterviewSummaryResponse(
         Long interviewId,
-        InterviewState interviewState,
         Category interviewCategory,
         LocalDateTime createdAt,
         String rootQuestion,
@@ -20,7 +18,6 @@ public record InterviewSummaryResponse(
     public InterviewSummaryResponse(Interview interview, Integer curAnswerCount, Boolean interviewAlreadyLiked) {
         this(
                 interview.getId(),
-                interview.getInterviewState(),
                 interview.getRootQuestion().getCategory(),
                 interview.getCreatedAt(),
                 interview.getRootQuestion().getContent(),
@@ -32,7 +29,7 @@ public record InterviewSummaryResponse(
         );
     }
 
-    public static InterviewSummaryResponse createOfTargetMember(Interview interview, Boolean interviewAlreadyLiked) {
+    public static InterviewSummaryResponse createOfOtherMember(Interview interview, Boolean interviewAlreadyLiked) {
         return new InterviewSummaryResponse(interview, null, interviewAlreadyLiked);
     }
 
@@ -40,7 +37,6 @@ public record InterviewSummaryResponse(
         if (interview.isInProgress()) {
             return new InterviewSummaryResponse(
                     interview.getId(),
-                    interview.getInterviewState(),
                     interview.getRootQuestion().getCategory(),
                     interview.getCreatedAt(),
                     interview.getRootQuestion().getContent(),
@@ -53,7 +49,6 @@ public record InterviewSummaryResponse(
         }
         return new InterviewSummaryResponse(
                 interview.getId(),
-                interview.getInterviewState(),
                 interview.getRootQuestion().getCategory(),
                 interview.getCreatedAt(),
                 interview.getRootQuestion().getContent(),

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewSummaryResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewSummaryResponse.java
@@ -2,10 +2,12 @@ package com.samhap.kokomen.interview.service.dto;
 
 import com.samhap.kokomen.category.domain.Category;
 import com.samhap.kokomen.interview.domain.Interview;
+import com.samhap.kokomen.interview.domain.InterviewState;
 import java.time.LocalDateTime;
 
 public record InterviewSummaryResponse(
         Long interviewId,
+        InterviewState interviewState,
         Category interviewCategory,
         LocalDateTime createdAt,
         String rootQuestion,
@@ -15,9 +17,10 @@ public record InterviewSummaryResponse(
         Long interviewLikeCount,
         Boolean interviewAlreadyLiked
 ) {
-    public InterviewSummaryResponse(Interview interview, Integer curAnswerCount, Boolean interviewAlreadyLiked) {
+    public InterviewSummaryResponse(Interview interview, InterviewState interviewState, Integer curAnswerCount, Boolean interviewAlreadyLiked) {
         this(
                 interview.getId(),
+                interviewState,
                 interview.getRootQuestion().getCategory(),
                 interview.getCreatedAt(),
                 interview.getRootQuestion().getContent(),
@@ -29,14 +32,19 @@ public record InterviewSummaryResponse(
         );
     }
 
-    public static InterviewSummaryResponse createOfOtherMember(Interview interview, Boolean interviewAlreadyLiked) {
-        return new InterviewSummaryResponse(interview, null, interviewAlreadyLiked);
+    public static InterviewSummaryResponse createOfOtherMemberForLoginMember(Interview interview, Boolean interviewAlreadyLiked) {
+        return new InterviewSummaryResponse(interview, null, null, interviewAlreadyLiked);
+    }
+
+    public static InterviewSummaryResponse createOfOtherMemberForLogoutMember(Interview interview) {
+        return new InterviewSummaryResponse(interview, null, null, false);
     }
 
     public static InterviewSummaryResponse createMine(Interview interview, Integer curAnswerCount, Boolean interviewAlreadyLiked) {
         if (interview.isInProgress()) {
             return new InterviewSummaryResponse(
                     interview.getId(),
+                    interview.getInterviewState(),
                     interview.getRootQuestion().getCategory(),
                     interview.getCreatedAt(),
                     interview.getRootQuestion().getContent(),
@@ -49,6 +57,7 @@ public record InterviewSummaryResponse(
         }
         return new InterviewSummaryResponse(
                 interview.getId(),
+                interview.getInterviewState(),
                 interview.getRootQuestion().getCategory(),
                 interview.getCreatedAt(),
                 interview.getRootQuestion().getContent(),

--- a/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
+++ b/src/main/java/com/samhap/kokomen/member/repository/MemberRepository.java
@@ -14,6 +14,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByKakaoId(Long kakaoId);
 
+    @Query(value = """
+            SELECT COUNT(*) + 1
+            FROM member
+            WHERE score > :score
+            """, nativeQuery = true)
+    long findRankByScore(@Param("score") int score);
+
     @Transactional
     @Modifying
     @Query("UPDATE Member m SET m.freeTokenCount = m.freeTokenCount - 1 WHERE m.id = :memberId AND m.freeTokenCount > 0")

--- a/src/main/java/com/samhap/kokomen/member/service/MemberService.java
+++ b/src/main/java/com/samhap/kokomen/member/service/MemberService.java
@@ -30,8 +30,9 @@ public class MemberService {
 
     public MyProfileResponse findMember(MemberAuth memberAuth) {
         Member member = readMember(memberAuth);
-
-        return new MyProfileResponse(member);
+        long rank = memberRepository.findRankByScore(member.getScore());
+        long totalMemberCount = memberRepository.count();
+        return new MyProfileResponse(member, totalMemberCount, rank);
     }
 
     @Transactional

--- a/src/main/java/com/samhap/kokomen/member/service/dto/MyProfileResponse.java
+++ b/src/main/java/com/samhap/kokomen/member/service/dto/MyProfileResponse.java
@@ -6,10 +6,12 @@ public record MyProfileResponse(
         Long id,
         String nickname,
         Integer score,
+        Long totalMemberCount,
+        Long rank,
         Integer tokenCount,
         Boolean profileCompleted
 ) {
-    public MyProfileResponse(Member member) {
-        this(member.getId(), member.getNickname(), member.getScore(), member.getFreeTokenCount(), member.getProfileCompleted());
+    public MyProfileResponse(Member member, Long totalMemberCount, Long rank) {
+        this(member.getId(), member.getNickname(), member.getScore(), totalMemberCount, rank, member.getFreeTokenCount(), member.getProfileCompleted());
     }
 }

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -476,9 +476,6 @@ class InterviewControllerTest extends BaseControllerTest {
 
         String responseJson = """
                 {
-                    "interviewee_nickname": "오상훈",
-                    "total_member_count": 2,
-                    "interviewee_rank": 1,
                     "interview_summaries": [
                         {
                             "interview_id": %d,
@@ -498,7 +495,10 @@ class InterviewControllerTest extends BaseControllerTest {
                             "interview_like_count": 0,
                             "interview_already_liked": false
                         }
-                    ]
+                    ],
+                    "interviewee_nickname": "오상훈",
+                    "total_member_count": 2,
+                    "interviewee_rank": 1
                 }
                 """.formatted(
                 finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(),
@@ -530,9 +530,6 @@ class InterviewControllerTest extends BaseControllerTest {
                                 parameterWithName("sort").description("정렬 기준 (기본값: id,desc)")
                         ),
                         responseFields(
-                                fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
-                                fieldWithPath("total_member_count").description("전체 회원 수"),
-                                fieldWithPath("interviewee_rank").description("면접자 등수"),
                                 fieldWithPath("interview_summaries[].interview_id").description("면접 ID"),
                                 fieldWithPath("interview_summaries[].interview_category").description("면접 카테고리"),
                                 fieldWithPath("interview_summaries[].created_at").description("생성 시간"),
@@ -540,7 +537,10 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("interview_summaries[].max_question_count").description("최대 질문 개수"),
                                 fieldWithPath("interview_summaries[].score").description("점수"),
                                 fieldWithPath("interview_summaries[].interview_like_count").description("면접 좋아요 수"),
-                                fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부")
+                                fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부"),
+                                fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
+                                fieldWithPath("total_member_count").description("전체 회원 수"),
+                                fieldWithPath("interviewee_rank").description("면접자 등수")
                         )
                 ));
     }
@@ -579,9 +579,6 @@ class InterviewControllerTest extends BaseControllerTest {
 
         String responseJson = """
                 {
-                    "interviewee_nickname": "오상훈",
-                    "total_member_count": 1,
-                    "interviewee_rank": 1,
                     "interview_summaries": [
                         {
                             "interview_id": %d,
@@ -601,7 +598,10 @@ class InterviewControllerTest extends BaseControllerTest {
                             "interview_like_count": 0,
                             "interview_already_liked": false
                         }
-                    ]
+                    ],
+                    "interviewee_nickname": "오상훈",
+                    "total_member_count": 1,
+                    "interviewee_rank": 1
                 }
                 """.formatted(
                 finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(),
@@ -627,9 +627,6 @@ class InterviewControllerTest extends BaseControllerTest {
                                 parameterWithName("sort").description("정렬 기준 (기본값: id,desc)")
                         ),
                         responseFields(
-                                fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
-                                fieldWithPath("total_member_count").description("전체 회원 수"),
-                                fieldWithPath("interviewee_rank").description("면접자 등수"),
                                 fieldWithPath("interview_summaries[].interview_id").description("면접 ID"),
                                 fieldWithPath("interview_summaries[].interview_category").description("면접 카테고리"),
                                 fieldWithPath("interview_summaries[].created_at").description("생성 시간"),
@@ -637,7 +634,10 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("interview_summaries[].max_question_count").description("최대 질문 개수"),
                                 fieldWithPath("interview_summaries[].score").description("점수"),
                                 fieldWithPath("interview_summaries[].interview_like_count").description("면접 좋아요 수"),
-                                fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부")
+                                fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부"),
+                                fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
+                                fieldWithPath("total_member_count").description("전체 회원 수"),
+                                fieldWithPath("interviewee_rank").description("면접자 등수")
                         )
                 ));
     }
@@ -732,14 +732,14 @@ class InterviewControllerTest extends BaseControllerTest {
     @Test
     void 다른_사용자의_완료된_인터뷰_결과_조회_로그인_버전() throws Exception {
         // given
-        Member member = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(1L).build());
-        Member readerMember = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).build());
+        Member interviewee = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(1L).score(100).build());
+        Member readerMember = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).score(0).build());
 
         MockHttpSession session = new MockHttpSession();
         session.setAttribute("MEMBER_ID", readerMember.getId());
 
         RootQuestion rootQuestion = rootQuestionRepository.save(RootQuestionFixtureBuilder.builder().content("자바의 특징은 무엇인가요?").build());
-        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(member).rootQuestion(rootQuestion).build());
+        Interview interview = interviewRepository.save(InterviewFixtureBuilder.builder().member(interviewee).rootQuestion(rootQuestion).build());
         Question question1 = questionRepository.save(QuestionFixtureBuilder.builder().interview(interview).content(rootQuestion.getContent()).build());
         Answer answer1 = answerRepository.save(
                 AnswerFixtureBuilder.builder().question(question1).content("자바는 객체지향 프로그래밍 언어입니다.").answerRank(AnswerRank.C).feedback("부족합니다.").build());
@@ -793,7 +793,10 @@ class InterviewControllerTest extends BaseControllerTest {
                 	"total_score": -30,
                 	"total_feedback": "제대로 좀 공부 해라.",
                 	"interview_like_count": 1,
-                	"interview_already_liked": true
+                	"interview_already_liked": true,
+                	"interviewee_nickname": "오상훈",
+                	"total_member_count": 2,
+                	"interviewee_rank": 1
                 }
                 """;
 
@@ -804,7 +807,7 @@ class InterviewControllerTest extends BaseControllerTest {
                         .session(session))
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
-                .andDo(document("interview-findOtherMemberResult-authenticated",
+                .andDo(document("interview-findOtherMemberInterviewResult-authenticated",
                         pathParameters(
                                 parameterWithName("interview_id").description("인터뷰 ID")
                         ),
@@ -821,7 +824,10 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("total_feedback").description("인터뷰 총 피드백"),
                                 fieldWithPath("total_score").description("인터뷰 총 점수"),
                                 fieldWithPath("interview_like_count").description("인터뷰 좋아요 수"),
-                                fieldWithPath("interview_already_liked").description("이미 인터뷰에 좋아요를 눌렀는지 여부")
+                                fieldWithPath("interview_already_liked").description("이미 인터뷰에 좋아요를 눌렀는지 여부"),
+                                fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
+                                fieldWithPath("total_member_count").description("전체 회원 수"),
+                                fieldWithPath("interviewee_rank").description("면접자 등수")
                         )
                 ));
     }
@@ -881,7 +887,10 @@ class InterviewControllerTest extends BaseControllerTest {
                 	"total_score": -30,
                 	"total_feedback": "제대로 좀 공부 해라.",
                 	"interview_like_count": 0,
-                	"interview_already_liked": false
+                	"interview_already_liked": false,
+                    "interviewee_nickname": "오상훈",
+                	"total_member_count": 1,
+                	"interviewee_rank": 1
                 }
                 """;
 
@@ -890,7 +899,7 @@ class InterviewControllerTest extends BaseControllerTest {
                         "/api/v1/interviews/{interview_id}/result", interview.getId()))
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
-                .andDo(document("interview-findOtherMemberResult-unauthenticated",
+                .andDo(document("interview-findOtherMemberInterviewResult-unauthenticated",
                         pathParameters(
                                 parameterWithName("interview_id").description("인터뷰 ID")
                         ),
@@ -907,7 +916,10 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("total_feedback").description("인터뷰 총 피드백"),
                                 fieldWithPath("total_score").description("인터뷰 총 점수"),
                                 fieldWithPath("interview_like_count").description("인터뷰 좋아요 수"),
-                                fieldWithPath("interview_already_liked").description("이미 인터뷰에 좋아요를 눌렀는지 여부")
+                                fieldWithPath("interview_already_liked").description("이미 인터뷰에 좋아요를 눌렀는지 여부"),
+                                fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
+                                fieldWithPath("total_member_count").description("전체 회원 수"),
+                                fieldWithPath("interviewee_rank").description("면접자 등수")
                         )
                 ));
     }

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -440,8 +440,8 @@ class InterviewControllerTest extends BaseControllerTest {
     @Test
     void 다른_사용자의_완료된_인터뷰_목록_조회_로그인_버전() throws Exception {
         // given
-        Member interviewee = memberRepository.save(MemberFixtureBuilder.builder().nickname("오상훈").kakaoId(1L).build());
-        Member readerMember = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).build());
+        Member interviewee = memberRepository.save(MemberFixtureBuilder.builder().nickname("오상훈").kakaoId(1L).score(100).build());
+        Member readerMember = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).score(0).build());
         MockHttpSession session = new MockHttpSession();
         session.setAttribute("MEMBER_ID", readerMember.getId());
 
@@ -477,7 +477,9 @@ class InterviewControllerTest extends BaseControllerTest {
         String responseJson = """
                 {
                     "interviewee_nickname": "오상훈",
-                    "interview_summary_responses": [
+                    "total_member_count": 2,
+                    "interviewee_rank": 1,
+                    "interview_summaries": [
                         {
                             "interview_id": %d,
                             "interview_category": "%s",
@@ -515,8 +517,8 @@ class InterviewControllerTest extends BaseControllerTest {
                         .session(session))
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
-                .andExpect(jsonPath("$.interview_summary_responses[0].created_at").exists())
-                .andExpect(jsonPath("$.interview_summary_responses[1].created_at").exists())
+                .andExpect(jsonPath("$.interview_summaries[0].created_at").exists())
+                .andExpect(jsonPath("$.interview_summaries[1].created_at").exists())
                 .andDo(document("interview-findOtherMemberInterviews-authenticated",
                         requestHeaders(
                                 headerWithName("Cookie").description("로그인 세션을 위한 JSESSIONID 쿠키")
@@ -529,14 +531,16 @@ class InterviewControllerTest extends BaseControllerTest {
                         ),
                         responseFields(
                                 fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
-                                fieldWithPath("interview_summary_responses[].interview_id").description("면접 ID"),
-                                fieldWithPath("interview_summary_responses[].interview_category").description("면접 카테고리"),
-                                fieldWithPath("interview_summary_responses[].created_at").description("생성 시간"),
-                                fieldWithPath("interview_summary_responses[].root_question").description("루트 질문"),
-                                fieldWithPath("interview_summary_responses[].max_question_count").description("최대 질문 개수"),
-                                fieldWithPath("interview_summary_responses[].score").description("점수"),
-                                fieldWithPath("interview_summary_responses[].interview_like_count").description("면접 좋아요 수"),
-                                fieldWithPath("interview_summary_responses[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부")
+                                fieldWithPath("total_member_count").description("전체 회원 수"),
+                                fieldWithPath("interviewee_rank").description("면접자 등수"),
+                                fieldWithPath("interview_summaries[].interview_id").description("면접 ID"),
+                                fieldWithPath("interview_summaries[].interview_category").description("면접 카테고리"),
+                                fieldWithPath("interview_summaries[].created_at").description("생성 시간"),
+                                fieldWithPath("interview_summaries[].root_question").description("루트 질문"),
+                                fieldWithPath("interview_summaries[].max_question_count").description("최대 질문 개수"),
+                                fieldWithPath("interview_summaries[].score").description("점수"),
+                                fieldWithPath("interview_summaries[].interview_like_count").description("면접 좋아요 수"),
+                                fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부")
                         )
                 ));
     }
@@ -574,36 +578,36 @@ class InterviewControllerTest extends BaseControllerTest {
         answerRepository.save(AnswerFixtureBuilder.builder().question(question6).build());
 
         String responseJson = """
-                [
-                	{
-                		"interview_id": %d,
-                		"interview_state": "%s",
-                		"interview_category": "%s",
-                		"root_question": "%s",
-                		"max_question_count": %d,
-                		"score": %s,
-                		"interview_like_count": %d,
-                		"interview_already_liked": false
-                	},
-                	{
-                		"interview_id": %d,
-                		"interview_state": "%s",
-                		"interview_category": "%s",
-                		"root_question": "%s",
-                		"max_question_count": %d,
-                		"score": %s,
-                		"interview_like_count": %d,
-                		"interview_already_liked": false
-                	}
-                ]
+                {
+                    "interviewee_nickname": "오상훈",
+                    "total_member_count": 1,
+                    "interviewee_rank": 1,
+                    "interview_summaries": [
+                        {
+                            "interview_id": %d,
+                            "interview_category": "%s",
+                            "root_question": "%s",
+                            "max_question_count": %d,
+                            "score": %s,
+                            "interview_like_count": 0,
+                            "interview_already_liked": false
+                        },
+                        {
+                            "interview_id": %d,
+                            "interview_category": "%s",
+                            "root_question": "%s",
+                            "max_question_count": %d,
+                            "score": %s,
+                            "interview_like_count": 0,
+                            "interview_already_liked": false
+                        }
+                    ]
+                }
                 """.formatted(
-                finishedInterview2.getId(), finishedInterview2.getInterviewState(), finishedInterview2.getRootQuestion().getCategory(),
+                finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(),
                 finishedInterview2.getRootQuestion().getContent(), finishedInterview2.getMaxQuestionCount(), finishedInterview2.getTotalScore(),
-                finishedInterview2.getLikeCount(),
-                finishedInterview1.getId(), finishedInterview1.getInterviewState(), finishedInterview1.getRootQuestion().getCategory(),
-                finishedInterview1.getRootQuestion().getContent(), finishedInterview1.getMaxQuestionCount(), finishedInterview1.getTotalScore(),
-                finishedInterview1.getLikeCount()
-        );
+                finishedInterview1.getId(), finishedInterview1.getRootQuestion().getCategory(),
+                finishedInterview1.getRootQuestion().getContent(), finishedInterview1.getMaxQuestionCount(), finishedInterview1.getTotalScore());
 
         // when & then
         mockMvc.perform(get("/api/v1/interviews")
@@ -613,8 +617,8 @@ class InterviewControllerTest extends BaseControllerTest {
                         .param("sort", "id,desc"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(responseJson))
-                .andExpect(jsonPath("$[0].created_at").exists())
-                .andExpect(jsonPath("$[1].created_at").exists())
+                .andExpect(jsonPath("$.interview_summaries[0].created_at").exists())
+                .andExpect(jsonPath("$.interview_summaries[1].created_at").exists())
                 .andDo(document("interview-findOtherMemberInterviews-unauthenticated",
                         queryParameters(
                                 parameterWithName("member_id").description("인터뷰이 멤버 id").optional(),
@@ -623,15 +627,17 @@ class InterviewControllerTest extends BaseControllerTest {
                                 parameterWithName("sort").description("정렬 기준 (기본값: id,desc)")
                         ),
                         responseFields(
-                                fieldWithPath("[].interview_id").description("면접 ID"),
-                                fieldWithPath("[].interview_state").description("면접 상태(항상 FINISHED)"),
-                                fieldWithPath("[].interview_category").description("면접 카테고리"),
-                                fieldWithPath("[].created_at").description("생성 시간"),
-                                fieldWithPath("[].root_question").description("루트 질문"),
-                                fieldWithPath("[].max_question_count").description("최대 질문 개수"),
-                                fieldWithPath("[].score").description("점수"),
-                                fieldWithPath("[].interview_like_count").description("면접 좋아요 수"),
-                                fieldWithPath("[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부")
+                                fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
+                                fieldWithPath("total_member_count").description("전체 회원 수"),
+                                fieldWithPath("interviewee_rank").description("면접자 등수"),
+                                fieldWithPath("interview_summaries[].interview_id").description("면접 ID"),
+                                fieldWithPath("interview_summaries[].interview_category").description("면접 카테고리"),
+                                fieldWithPath("interview_summaries[].created_at").description("생성 시간"),
+                                fieldWithPath("interview_summaries[].root_question").description("루트 질문"),
+                                fieldWithPath("interview_summaries[].max_question_count").description("최대 질문 개수"),
+                                fieldWithPath("interview_summaries[].score").description("점수"),
+                                fieldWithPath("interview_summaries[].interview_like_count").description("면접 좋아요 수"),
+                                fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부")
                         )
                 ));
     }

--- a/src/test/java/com/samhap/kokomen/interview/docs/InterviewDocsTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/docs/InterviewDocsTest.java
@@ -144,7 +144,7 @@ public class InterviewDocsTest extends DocsTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/interviews/{interview_id}/result", interviewId))
-                .andDo(document("interview-findOtherMemberResult-exception" + docsNo));
+                .andDo(document("interview-findOtherMemberInterviewResult-exception" + docsNo));
     }
 
     private static Stream<Arguments> provideFindTotalFeedbacksExceptionCase() {

--- a/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
@@ -370,7 +370,7 @@ class InterviewServiceTest extends BaseTest {
                 targetMember.getId(),
                 new MemberAuth(readerMember.getId()),
                 PageRequest.of(0, 10, Sort.by(Direction.DESC, "id"))
-        );
+        ).InterviewSummaryResponses();
 
         // then
         assertAll(

--- a/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
@@ -370,7 +370,7 @@ class InterviewServiceTest extends BaseTest {
                 targetMember.getId(),
                 new MemberAuth(readerMember.getId()),
                 PageRequest.of(0, 10, Sort.by(Direction.DESC, "id"))
-        ).InterviewSummaryResponses();
+        ).interviewSummaries();
 
         // then
         assertAll(

--- a/src/test/java/com/samhap/kokomen/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/member/controller/MemberControllerTest.java
@@ -39,7 +39,7 @@ class MemberControllerTest extends BaseControllerTest {
     private InterviewRepository interviewRepository;
 
     @Test
-    void 자신의_정보를_조회한다() throws Exception {
+    void 멤버_프로필_조회() throws Exception {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
         MockHttpSession session = new MockHttpSession();
@@ -50,6 +50,8 @@ class MemberControllerTest extends BaseControllerTest {
                     "id": %d,
                     "nickname": %s,
                     "score": %d,
+                    "total_member_count": 1,
+                    "rank": 1,
                     "token_count": %d,
                     "profile_completed": %s
                 }
@@ -70,6 +72,8 @@ class MemberControllerTest extends BaseControllerTest {
                                 fieldWithPath("id").description("회원 id"),
                                 fieldWithPath("nickname").description("회원 닉네임"),
                                 fieldWithPath("score").description("현재 회원 점수"),
+                                fieldWithPath("total_member_count").description("전체 회원 수"),
+                                fieldWithPath("rank").description("회원 등수"),
                                 fieldWithPath("token_count").description("현재 회원 토큰 개수"),
                                 fieldWithPath("profile_completed").description("프로필 완성 여부")
                         )

--- a/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/samhap/kokomen/member/repository/MemberRepositoryTest.java
@@ -27,6 +27,20 @@ class MemberRepositoryTest extends BaseTest {
     private RootQuestionRepository rootQuestionRepository;
 
     @Test
+    void findRankByScore() {
+        // given
+        Member ranker1 = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(1L).score(100).build());
+        Member ranker2 = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(2L).score(50).build());
+        Member ranker3 = memberRepository.save(MemberFixtureBuilder.builder().kakaoId(3L).score(0).build());
+
+        // when
+        long rank = memberRepository.findRankByScore(ranker2.getScore());
+
+        // then
+        assertThat(rank).isEqualTo(2L);
+    }
+
+    @Test
     void free_token_count를_1_감소시킨다() {
         // given
         Member member = memberRepository.save(MemberFixtureBuilder.builder().freeTokenCount(1).build());


### PR DESCRIPTION
# 작업 내용
- 남의 인터뷰 목록 조회 시, 응답에
  - 닉네임 추가
  - interview_state는 삭제 (FINISHED인 인터뷰만 조회할 수 있으니까)
  - 현재 총 회원수, 인터뷰이 등수 추가
- 남의 인터뷰 결과 조회 시, 응답에
  - 닉네임 추가
  - 현재 총 회원수, 인터뷰이 등수 추가
- 내 프로필 조회 시
  - 현재 총 회원수, 인터뷰이 등수 추가

# 스크린샷

# 참고 사항
1. 남의 인터뷰 목록 조회 API
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/35d2bda5-6120-4dac-b3bd-a20beb27814e" />

2. 남의 인터뷰 결과 조회 API

![image](https://github.com/user-attachments/assets/c184f040-e625-4dfe-a0ab-9ecdb648993d)

- InterviewService에서 위와 같이 복잡한 구조의 DTO를 반환하고 있습니다.
- 이번 요구사항과 같이 DTO에 집어넣어줘야 하는 데이터들이 추가된다고 했을 때, Service 메서드의 변경사항을 최소화하는 방법이 무엇일지 생각해봤습니다.
- DTO 생성 시, 인자로 넣어주는 엔티티들이 가진 정보로 커버칠 수 있으면 Service 메서드는 전혀 변경될 필요가 없지만, 그렇지 않은 경우 데이터를 조회해오는 로직은 Service에 추가될 수밖에 없습니다.
  - 다만 Service에서의 변경은 해당 로직들을 가져오고, 그들을 DTO 생성 시 인자로 추가되는 방향으로만 변경되는게 최적이라고 생각했습니다.
