### PR TITLE
[Feat] - 다른 사람의 인터뷰 목록/결과 조회 API, 자신의 인터뷰 목록 조회 API 응답에 조회수 추가

### DIFF
--- a/src/main/java/com/samhap/kokomen/global/service/RedisService.java
+++ b/src/main/java/com/samhap/kokomen/global/service/RedisService.java
@@ -3,6 +3,7 @@ package com.samhap.kokomen.global.service;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -31,11 +32,13 @@ public class RedisService {
         return setSuccess;
     }
 
-    public void incrementKey(String key) {
+    public Long incrementKey(String key) {
         Long count = redisTemplate.opsForValue().increment(key, 1);
         if (count == null) {
             throw new IllegalStateException("Redis 카운트 증가 실패. key: " + key);
         }
+
+        return count;
     }
 
     public boolean expireKey(String key, Duration ttl) {
@@ -54,6 +57,12 @@ public class RedisService {
                 .build();
 
         return redisTemplate.scan(scanOptions);
+    }
+
+    public <T> Optional<T> get(String key, Class<T> type) {
+        Object value = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(value)
+                .map(type::cast);
     }
 
     public Map<String, Object> multiGet(List<String> keys) {

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
@@ -10,7 +10,8 @@ public record InterviewSummaryResponses(
         List<InterviewSummaryResponse> interviewSummaries,
         Long totalMemberCount,
         Long intervieweeRank,
-        String intervieweeNickname
+        String intervieweeNickname,
+        Long totalPageCount
 ) {
     public static InterviewSummaryResponses createOfOtherMemberForAuthorized(
             String intervieweeNickname,
@@ -18,7 +19,8 @@ public record InterviewSummaryResponses(
             Long intervieweeRank,
             List<Interview> interviews,
             Set<Long> likedInterviewIds,
-            Map<Long, Long> viewCounts
+            Map<Long, Long> viewCounts,
+            Long totalPageCount
     ) {
         List<InterviewSummaryResponse> interviewSummaries = interviews.stream()
                 .map(interview -> InterviewSummaryResponse.createOfOtherMemberForAuthorized(interview, viewCounts.get(interview.getId()),
@@ -26,7 +28,7 @@ public record InterviewSummaryResponses(
                 .toList();
 
         return new InterviewSummaryResponses(
-                interviewSummaries, totalMemberCount, intervieweeRank, intervieweeNickname
+                interviewSummaries, totalMemberCount, intervieweeRank, intervieweeNickname, totalPageCount
         );
     }
 
@@ -35,14 +37,15 @@ public record InterviewSummaryResponses(
             Long totalMemberCount,
             Long intervieweeRank,
             List<Interview> interviews,
-            Map<Long, Long> viewCounts
+            Map<Long, Long> viewCounts,
+            Long pageCount
     ) {
         List<InterviewSummaryResponse> interviewSummaries = interviews.stream()
                 .map(interview -> InterviewSummaryResponse.createOfOtherMemberForUnauthorized(interview, viewCounts.get(interview.getId())))
                 .toList();
 
         return new InterviewSummaryResponses(
-                interviewSummaries, totalMemberCount, intervieweeRank, intervieweeNickname
+                interviewSummaries, totalMemberCount, intervieweeRank, intervieweeNickname, pageCount
         );
     }
 }

--- a/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
+++ b/src/main/java/com/samhap/kokomen/interview/external/dto/response/InterviewSummaryResponses.java
@@ -3,6 +3,7 @@ package com.samhap.kokomen.interview.external.dto.response;
 import com.samhap.kokomen.interview.domain.Interview;
 import com.samhap.kokomen.interview.service.dto.InterviewSummaryResponse;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public record InterviewSummaryResponses(
@@ -16,10 +17,12 @@ public record InterviewSummaryResponses(
             Long totalMemberCount,
             Long intervieweeRank,
             List<Interview> interviews,
-            Set<Long> likedInterviewIds
+            Set<Long> likedInterviewIds,
+            Map<Long, Long> viewCounts
     ) {
         List<InterviewSummaryResponse> interviewSummaries = interviews.stream()
-                .map(interview -> InterviewSummaryResponse.createOfOtherMemberForAuthorized(interview, likedInterviewIds.contains(interview.getId())))
+                .map(interview -> InterviewSummaryResponse.createOfOtherMemberForAuthorized(interview, viewCounts.get(interview.getId()),
+                        likedInterviewIds.contains(interview.getId())))
                 .toList();
 
         return new InterviewSummaryResponses(
@@ -31,10 +34,11 @@ public record InterviewSummaryResponses(
             String intervieweeNickname,
             Long totalMemberCount,
             Long intervieweeRank,
-            List<Interview> interviews
+            List<Interview> interviews,
+            Map<Long, Long> viewCounts
     ) {
         List<InterviewSummaryResponse> interviewSummaries = interviews.stream()
-                .map(InterviewSummaryResponse::createOfOtherMemberForUnauthorized)
+                .map(interview -> InterviewSummaryResponse.createOfOtherMemberForUnauthorized(interview, viewCounts.get(interview.getId())))
                 .toList();
 
         return new InterviewSummaryResponses(

--- a/src/main/java/com/samhap/kokomen/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/samhap/kokomen/interview/repository/InterviewRepository.java
@@ -16,6 +16,8 @@ public interface InterviewRepository extends JpaRepository<Interview, Long> {
 
     List<Interview> findByMemberAndInterviewState(Member member, InterviewState interviewState, Pageable pageable);
 
+    Long countByMemberAndInterviewState(Member member, InterviewState interviewState);
+
     @Transactional
     @Modifying
     @Query("UPDATE Interview i SET i.likeCount = i.likeCount + 1 WHERE i.id = :interviewId")

--- a/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/InterviewService.java
@@ -35,8 +35,10 @@ import com.samhap.kokomen.member.domain.Member;
 import com.samhap.kokomen.member.repository.MemberRepository;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -166,7 +168,8 @@ public class InterviewService {
         Set<Long> likedInterviewIds = interviewLikeRepository.findLikedInterviewIds(member.getId(), finishedInterviewIds);
 
         return interviews.stream()
-                .map(interview -> InterviewSummaryResponse.createMine(interview, countCurAnswers(interview), likedInterviewIds.contains(interview.getId())))
+                .map(interview -> InterviewSummaryResponse.createMine(interview, countCurAnswers(interview), findViewCount(interview),
+                        likedInterviewIds.contains(interview.getId())))
                 .toList();
     }
 
@@ -187,15 +190,18 @@ public class InterviewService {
         long totalMemberCount = memberRepository.count();
 
         List<Interview> finishedInterviews = findInterviews(interviewee, InterviewState.FINISHED, pageable);
+        Map<Long, Long> viewCounts = finishedInterviews.stream()
+                .collect(Collectors.toMap(Interview::getId, this::findViewCount));
         if (memberAuth.isAuthenticated()) {
             Member readerMember = readMember(memberAuth.memberId());
             List<Long> finishedInterviewIds = finishedInterviews.stream().map(Interview::getId).toList();
             Set<Long> likedInterviewIds = interviewLikeRepository.findLikedInterviewIds(readerMember.getId(), finishedInterviewIds);
 
             return InterviewSummaryResponses.createOfOtherMemberForAuthorized(interviewee.getNickname(), totalMemberCount, intervieweeRank, finishedInterviews,
-                    likedInterviewIds);
+                    likedInterviewIds, viewCounts);
         }
-        return InterviewSummaryResponses.createOfOtherMemberForUnAuthorized(interviewee.getNickname(), totalMemberCount, intervieweeRank, finishedInterviews);
+        return InterviewSummaryResponses.createOfOtherMemberForUnAuthorized(interviewee.getNickname(), totalMemberCount, intervieweeRank, finishedInterviews,
+                viewCounts);
     }
 
     // TODO: 동적 쿼리 개선하기
@@ -233,9 +239,7 @@ public class InterviewService {
         long intervieweeRank = memberRepository.findRankByScore(interviewee.getScore());
 
         validateInterviewFinished(interview);
-        if (!isInterviewee(memberAuth, interview)) {
-            increaseViewCount(interview, clientIp);
-        }
+        long viewCount = increaseViewCountIfNotInterviewee(interview, memberAuth, clientIp);
         List<Answer> answers = answerRepository.findByQuestionIn(questionRepository.findByInterview(interview));
         if (memberAuth.isAuthenticated()) {
             Member readerMember = readMember(memberAuth.memberId());
@@ -243,11 +247,18 @@ public class InterviewService {
             List<Long> answerIds = answers.stream().map(Answer::getId).toList();
             Set<Long> likedAnswerIds = answerLikeRepository.findLikedAnswerIds(readerMember.getId(), answerIds);
 
-            return InterviewResultResponse.createOfOtherMemberForAuthorized(answers, likedAnswerIds, interview, interviewAlreadyLiked,
+            return InterviewResultResponse.createOfOtherMemberForAuthorized(answers, likedAnswerIds, interview, viewCount, interviewAlreadyLiked,
                     interview.getMember().getNickname(), totalMemberCount, intervieweeRank);
         }
 
-        return InterviewResultResponse.createOfOtherMemberForUnauthorized(answers, interview, interviewee.getNickname(), totalMemberCount, intervieweeRank);
+        return InterviewResultResponse.createOfOtherMemberForUnauthorized(answers, interview, viewCount, interviewee.getNickname(), totalMemberCount,
+                intervieweeRank);
+    }
+
+    private Long findViewCount(Interview interview) {
+        return redisService.get(createInterviewViewCountKey(interview), String.class)
+                .map(Long::valueOf)
+                .orElse(interview.getViewCount());
     }
 
     private void validateInterviewFinished(Interview interview) {
@@ -260,10 +271,17 @@ public class InterviewService {
         return memberAuth.isAuthenticated() && interview.isInterviewee(readMember(memberAuth.memberId()));
     }
 
-    private void increaseViewCount(Interview interview, ClientIp clientIp) {
+    private Long increaseViewCountIfNotInterviewee(Interview interview, MemberAuth memberAuth, ClientIp clientIp) {
+        if (isInterviewee(memberAuth, interview)) {
+            return findViewCount(interview);
+        }
+        return increaseViewCount(interview, clientIp);
+    }
+
+    private Long increaseViewCount(Interview interview, ClientIp clientIp) {
         String viewCountLockKey = createInterviewViewCountLockKey(interview, clientIp);
         if (!redisService.acquireLock(viewCountLockKey, Duration.ofDays(1))) {
-            return;
+            return findViewCount(interview);
         }
 
         String viewCountKey = createInterviewViewCountKey(interview);
@@ -271,7 +289,7 @@ public class InterviewService {
         if (!expireSuccess) {
             redisService.setIfAbsent(viewCountKey, String.valueOf(interview.getViewCount()), Duration.ofDays(2));
         }
-        redisService.incrementKey(viewCountKey);
+        return redisService.incrementKey(viewCountKey);
     }
 
     public static String createInterviewViewCountLockKey(Interview interview, ClientIp clientIp) {

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewResultResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewResultResponse.java
@@ -10,6 +10,7 @@ public record InterviewResultResponse(
         List<FeedbackResponse> feedbacks,
         String totalFeedback,
         Integer totalScore,
+        Long interviewViewCount,
         Long interviewLikeCount,
         Boolean interviewAlreadyLiked,
         String intervieweeNickname,
@@ -33,6 +34,7 @@ public record InterviewResultResponse(
                 null,
                 null,
                 null,
+                null,
                 member.getScore(),
                 member.getScore() - interview.getTotalScore()
         );
@@ -42,6 +44,7 @@ public record InterviewResultResponse(
             List<Answer> answers,
             Set<Long> likedAnswerIds,
             Interview interview,
+            Long interviewViewCount,
             Boolean interviewAlreadyLiked,
             String intervieweeNickname,
             Long totalMemberCount,
@@ -55,6 +58,7 @@ public record InterviewResultResponse(
                 feedbackResponses,
                 interview.getTotalFeedback(),
                 interview.getTotalScore(),
+                interviewViewCount,
                 interview.getLikeCount(),
                 interviewAlreadyLiked,
                 intervieweeNickname,
@@ -68,6 +72,7 @@ public record InterviewResultResponse(
     public static InterviewResultResponse createOfOtherMemberForUnauthorized(
             List<Answer> answers,
             Interview interview,
+            Long interviewViewCount,
             String intervieweeNickname,
             Long totalMemberCount,
             Long intervieweeRank
@@ -80,6 +85,7 @@ public record InterviewResultResponse(
                 feedbackResponses,
                 interview.getTotalFeedback(),
                 interview.getTotalScore(),
+                interviewViewCount,
                 interview.getLikeCount(),
                 false,
                 intervieweeNickname,

--- a/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewSummaryResponse.java
+++ b/src/main/java/com/samhap/kokomen/interview/service/dto/InterviewSummaryResponse.java
@@ -14,10 +14,11 @@ public record InterviewSummaryResponse(
         Integer maxQuestionCount,
         Integer curAnswerCount,
         Integer score,
+        Long interviewViewCount,
         Long interviewLikeCount,
         Boolean interviewAlreadyLiked
 ) {
-    public InterviewSummaryResponse(Interview interview, InterviewState interviewState, Integer curAnswerCount, Boolean interviewAlreadyLiked) {
+    public InterviewSummaryResponse(Interview interview, InterviewState interviewState, Integer curAnswerCount, Long viewCount, Boolean interviewAlreadyLiked) {
         this(
                 interview.getId(),
                 interviewState,
@@ -27,20 +28,21 @@ public record InterviewSummaryResponse(
                 interview.getMaxQuestionCount(),
                 curAnswerCount,
                 interview.getTotalScore(),
+                viewCount,
                 interview.getLikeCount(),
                 interviewAlreadyLiked
         );
     }
 
-    public static InterviewSummaryResponse createOfOtherMemberForAuthorized(Interview interview, Boolean interviewAlreadyLiked) {
-        return new InterviewSummaryResponse(interview, null, null, interviewAlreadyLiked);
+    public static InterviewSummaryResponse createOfOtherMemberForAuthorized(Interview interview, Long viewCount, Boolean interviewAlreadyLiked) {
+        return new InterviewSummaryResponse(interview, null, null, viewCount, interviewAlreadyLiked);
     }
 
-    public static InterviewSummaryResponse createOfOtherMemberForUnauthorized(Interview interview) {
-        return new InterviewSummaryResponse(interview, null, null, false);
+    public static InterviewSummaryResponse createOfOtherMemberForUnauthorized(Interview interview, Long viewCount) {
+        return new InterviewSummaryResponse(interview, null, null, viewCount, false);
     }
 
-    public static InterviewSummaryResponse createMine(Interview interview, Integer curAnswerCount, Boolean interviewAlreadyLiked) {
+    public static InterviewSummaryResponse createMine(Interview interview, Integer curAnswerCount, Long viewCount, Boolean interviewAlreadyLiked) {
         if (interview.isInProgress()) {
             return new InterviewSummaryResponse(
                     interview.getId(),
@@ -50,6 +52,7 @@ public record InterviewSummaryResponse(
                     interview.getRootQuestion().getContent(),
                     interview.getMaxQuestionCount(),
                     curAnswerCount,
+                    null,
                     null,
                     null,
                     null
@@ -64,6 +67,7 @@ public record InterviewSummaryResponse(
                 interview.getMaxQuestionCount(),
                 curAnswerCount,
                 interview.getTotalScore(),
+                viewCount,
                 interview.getLikeCount(),
                 interviewAlreadyLiked
         );

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -505,7 +505,8 @@ class InterviewControllerTest extends BaseControllerTest {
                     ],
                     "interviewee_nickname": "오상훈",
                     "total_member_count": 2,
-                    "interviewee_rank": 1
+                    "interviewee_rank": 1,
+                    "total_page_count": 1
                 }
                 """.formatted(
                 finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(), finishedInterview2.getRootQuestion().getContent(),
@@ -548,7 +549,8 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
                                 fieldWithPath("total_member_count").description("전체 회원 수"),
-                                fieldWithPath("interviewee_rank").description("면접자 등수")
+                                fieldWithPath("interviewee_rank").description("면접자 등수"),
+                                fieldWithPath("total_page_count").description("전체 페이지 수")
                         )
                 ));
     }
@@ -611,7 +613,8 @@ class InterviewControllerTest extends BaseControllerTest {
                     ],
                     "interviewee_nickname": "오상훈",
                     "total_member_count": 1,
-                    "interviewee_rank": 1
+                    "interviewee_rank": 1,
+                    "total_page_count": 1
                 }
                 """.formatted(
                 finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(), finishedInterview2.getRootQuestion().getContent(),
@@ -648,7 +651,8 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
                                 fieldWithPath("total_member_count").description("전체 회원 수"),
-                                fieldWithPath("interviewee_rank").description("면접자 등수")
+                                fieldWithPath("interviewee_rank").description("면접자 등수"),
+                                fieldWithPath("total_page_count").description("전체 페이지 수")
                         )
                 ));
     }

--- a/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/controller/InterviewControllerTest.java
@@ -362,7 +362,7 @@ class InterviewControllerTest extends BaseControllerTest {
         questionRepository.save(QuestionFixtureBuilder.builder().interview(inProgressInterview).content(rootQuestion1.getContent()).build());
 
         Interview finishedInterview = interviewRepository.save(InterviewFixtureBuilder.builder()
-                .member(member).rootQuestion(rootQuestion2).maxQuestionCount(3).totalScore(20).interviewState(InterviewState.FINISHED).build());
+                .member(member).rootQuestion(rootQuestion2).maxQuestionCount(3).viewCount(2L).totalScore(20).interviewState(InterviewState.FINISHED).build());
         Question question1 = questionRepository.save(QuestionFixtureBuilder.builder().interview(finishedInterview).content(rootQuestion2.getContent()).build());
         answerRepository.save(AnswerFixtureBuilder.builder().question(question1).build());
         Question question2 = questionRepository.save(QuestionFixtureBuilder.builder().interview(finishedInterview).build());
@@ -382,6 +382,7 @@ class InterviewControllerTest extends BaseControllerTest {
                 		"max_question_count": %d,
                 		"cur_answer_count": %d,
                 		"score": %s,
+                		"interview_view_count": %d,
                 		"interview_like_count": 1,
                 		"interview_already_liked": true
                 	},
@@ -397,6 +398,7 @@ class InterviewControllerTest extends BaseControllerTest {
                 """.formatted(
                 finishedInterview.getId(), finishedInterview.getInterviewState(), finishedInterview.getRootQuestion().getCategory(),
                 finishedInterview.getRootQuestion().getContent(), finishedInterview.getMaxQuestionCount(), 3, finishedInterview.getTotalScore(),
+                finishedInterview.getViewCount(),
                 inProgressInterview.getId(), inProgressInterview.getInterviewState(), inProgressInterview.getRootQuestion().getCategory(),
                 inProgressInterview.getRootQuestion().getContent(), inProgressInterview.getMaxQuestionCount(), 0, inProgressInterview.getLikeCount()
         );
@@ -431,6 +433,7 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("[].max_question_count").description("최대 질문 개수"),
                                 fieldWithPath("[].cur_answer_count").description("현재 답변 개수"),
                                 fieldWithPath("[].score").description("점수 (면접이 FINISHED 인 경우에만)").optional(),
+                                fieldWithPath("[].interview_view_count").description("면접 조회 수 (면접이 FINISHED 인 경우에만)").optional(),
                                 fieldWithPath("[].interview_like_count").description("면접 좋아요 수 (면접이 FINISHED 인 경우에만)").optional(),
                                 fieldWithPath("[].interview_already_liked").description("면접에 이미 좋아요를 눌렀는지 여부 (면접이 FINISHED 인 경우에만)").optional()
                         )
@@ -453,7 +456,8 @@ class InterviewControllerTest extends BaseControllerTest {
         questionRepository.save(QuestionFixtureBuilder.builder().interview(inProgressInterview).content(rootQuestion1.getContent()).build());
 
         Interview finishedInterview1 = interviewRepository.save(InterviewFixtureBuilder.builder()
-                .member(interviewee).rootQuestion(rootQuestion2).maxQuestionCount(3).totalScore(20).interviewState(InterviewState.FINISHED).build());
+                .member(interviewee).rootQuestion(rootQuestion2).maxQuestionCount(3).viewCount(2L).totalScore(20).interviewState(InterviewState.FINISHED)
+                .build());
         Question question1 = questionRepository.save(
                 QuestionFixtureBuilder.builder().interview(finishedInterview1).content(rootQuestion2.getContent()).build());
         answerRepository.save(AnswerFixtureBuilder.builder().question(question1).build());
@@ -463,7 +467,8 @@ class InterviewControllerTest extends BaseControllerTest {
         answerRepository.save(AnswerFixtureBuilder.builder().question(question3).build());
 
         Interview finishedInterview2 = interviewRepository.save(InterviewFixtureBuilder.builder()
-                .member(interviewee).rootQuestion(rootQuestion3).maxQuestionCount(3).totalScore(20).interviewState(InterviewState.FINISHED).build());
+                .member(interviewee).rootQuestion(rootQuestion3).maxQuestionCount(3).viewCount(3L).totalScore(20).interviewState(InterviewState.FINISHED)
+                .build());
         Question question4 = questionRepository.save(
                 QuestionFixtureBuilder.builder().interview(finishedInterview2).content(rootQuestion3.getContent()).build());
         answerRepository.save(AnswerFixtureBuilder.builder().question(question4).build());
@@ -483,6 +488,7 @@ class InterviewControllerTest extends BaseControllerTest {
                             "root_question": "%s",
                             "max_question_count": %d,
                             "score": %s,
+                            "interview_view_count": %d,
                             "interview_like_count": 1,
                             "interview_already_liked": true
                         },
@@ -492,6 +498,7 @@ class InterviewControllerTest extends BaseControllerTest {
                             "root_question": "%s",
                             "max_question_count": %d,
                             "score": %s,
+                            "interview_view_count": %d,
                             "interview_like_count": 0,
                             "interview_already_liked": false
                         }
@@ -501,10 +508,10 @@ class InterviewControllerTest extends BaseControllerTest {
                     "interviewee_rank": 1
                 }
                 """.formatted(
-                finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(),
-                finishedInterview2.getRootQuestion().getContent(), finishedInterview2.getMaxQuestionCount(), finishedInterview2.getTotalScore(),
-                finishedInterview1.getId(), finishedInterview1.getRootQuestion().getCategory(),
-                finishedInterview1.getRootQuestion().getContent(), finishedInterview1.getMaxQuestionCount(), finishedInterview1.getTotalScore()
+                finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(), finishedInterview2.getRootQuestion().getContent(),
+                finishedInterview2.getMaxQuestionCount(), finishedInterview2.getTotalScore(), finishedInterview2.getViewCount(),
+                finishedInterview1.getId(), finishedInterview1.getRootQuestion().getCategory(), finishedInterview1.getRootQuestion().getContent(),
+                finishedInterview1.getMaxQuestionCount(), finishedInterview1.getTotalScore(), finishedInterview1.getViewCount()
         );
 
         // when & then
@@ -536,6 +543,7 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("interview_summaries[].root_question").description("루트 질문"),
                                 fieldWithPath("interview_summaries[].max_question_count").description("최대 질문 개수"),
                                 fieldWithPath("interview_summaries[].score").description("점수"),
+                                fieldWithPath("interview_summaries[].interview_view_count").description("면접 조회 수"),
                                 fieldWithPath("interview_summaries[].interview_like_count").description("면접 좋아요 수"),
                                 fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
@@ -558,7 +566,7 @@ class InterviewControllerTest extends BaseControllerTest {
         questionRepository.save(QuestionFixtureBuilder.builder().interview(inProgressInterview).content(rootQuestion1.getContent()).build());
 
         Interview finishedInterview1 = interviewRepository.save(InterviewFixtureBuilder.builder()
-                .member(member).rootQuestion(rootQuestion2).maxQuestionCount(3).totalScore(20).interviewState(InterviewState.FINISHED).build());
+                .member(member).rootQuestion(rootQuestion2).maxQuestionCount(3).viewCount(2L).totalScore(20).interviewState(InterviewState.FINISHED).build());
         Question question1 = questionRepository.save(
                 QuestionFixtureBuilder.builder().interview(finishedInterview1).content(rootQuestion2.getContent()).build());
         answerRepository.save(AnswerFixtureBuilder.builder().question(question1).build());
@@ -568,7 +576,7 @@ class InterviewControllerTest extends BaseControllerTest {
         answerRepository.save(AnswerFixtureBuilder.builder().question(question3).build());
 
         Interview finishedInterview2 = interviewRepository.save(InterviewFixtureBuilder.builder()
-                .member(member).rootQuestion(rootQuestion3).maxQuestionCount(3).totalScore(20).interviewState(InterviewState.FINISHED).build());
+                .member(member).rootQuestion(rootQuestion3).maxQuestionCount(3).viewCount(3L).totalScore(20).interviewState(InterviewState.FINISHED).build());
         Question question4 = questionRepository.save(
                 QuestionFixtureBuilder.builder().interview(finishedInterview2).content(rootQuestion3.getContent()).build());
         answerRepository.save(AnswerFixtureBuilder.builder().question(question4).build());
@@ -586,6 +594,7 @@ class InterviewControllerTest extends BaseControllerTest {
                             "root_question": "%s",
                             "max_question_count": %d,
                             "score": %s,
+                            "interview_view_count": %d,
                             "interview_like_count": 0,
                             "interview_already_liked": false
                         },
@@ -595,6 +604,7 @@ class InterviewControllerTest extends BaseControllerTest {
                             "root_question": "%s",
                             "max_question_count": %d,
                             "score": %s,
+                            "interview_view_count": %d,
                             "interview_like_count": 0,
                             "interview_already_liked": false
                         }
@@ -604,10 +614,10 @@ class InterviewControllerTest extends BaseControllerTest {
                     "interviewee_rank": 1
                 }
                 """.formatted(
-                finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(),
-                finishedInterview2.getRootQuestion().getContent(), finishedInterview2.getMaxQuestionCount(), finishedInterview2.getTotalScore(),
-                finishedInterview1.getId(), finishedInterview1.getRootQuestion().getCategory(),
-                finishedInterview1.getRootQuestion().getContent(), finishedInterview1.getMaxQuestionCount(), finishedInterview1.getTotalScore());
+                finishedInterview2.getId(), finishedInterview2.getRootQuestion().getCategory(), finishedInterview2.getRootQuestion().getContent(),
+                finishedInterview2.getMaxQuestionCount(), finishedInterview2.getTotalScore(), finishedInterview2.getViewCount(),
+                finishedInterview1.getId(), finishedInterview1.getRootQuestion().getCategory(), finishedInterview1.getRootQuestion().getContent(),
+                finishedInterview1.getMaxQuestionCount(), finishedInterview1.getTotalScore(), finishedInterview1.getViewCount());
 
         // when & then
         mockMvc.perform(get("/api/v1/interviews")
@@ -633,6 +643,7 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("interview_summaries[].root_question").description("루트 질문"),
                                 fieldWithPath("interview_summaries[].max_question_count").description("최대 질문 개수"),
                                 fieldWithPath("interview_summaries[].score").description("점수"),
+                                fieldWithPath("interview_summaries[].interview_view_count").description("면접 조회 수"),
                                 fieldWithPath("interview_summaries[].interview_like_count").description("면접 좋아요 수"),
                                 fieldWithPath("interview_summaries[].interview_already_liked").description("이미 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
@@ -792,6 +803,7 @@ class InterviewControllerTest extends BaseControllerTest {
                 	],
                 	"total_score": -30,
                 	"total_feedback": "제대로 좀 공부 해라.",
+                	"interview_view_count": 1, // 다른 사용자의 인터뷰 결과 조회 시 조회수가 1 증가합니다.
                 	"interview_like_count": 1,
                 	"interview_already_liked": true,
                 	"interviewee_nickname": "오상훈",
@@ -823,6 +835,7 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("feedbacks[].answer_already_liked").description("이미 답변에 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("total_feedback").description("인터뷰 총 피드백"),
                                 fieldWithPath("total_score").description("인터뷰 총 점수"),
+                                fieldWithPath("interview_view_count").description("인터뷰 조회 수"),
                                 fieldWithPath("interview_like_count").description("인터뷰 좋아요 수"),
                                 fieldWithPath("interview_already_liked").description("이미 인터뷰에 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("interviewee_nickname").description("면접자 닉네임"),
@@ -886,6 +899,7 @@ class InterviewControllerTest extends BaseControllerTest {
                 	],
                 	"total_score": -30,
                 	"total_feedback": "제대로 좀 공부 해라.",
+                	"interview_view_count": 1, // 다른 사용자의 인터뷰 결과 조회 시 조회수가 1 증가합니다.
                 	"interview_like_count": 0,
                 	"interview_already_liked": false,
                     "interviewee_nickname": "오상훈",
@@ -915,6 +929,7 @@ class InterviewControllerTest extends BaseControllerTest {
                                 fieldWithPath("feedbacks[].answer_already_liked").description("이미 답변에 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("total_feedback").description("인터뷰 총 피드백"),
                                 fieldWithPath("total_score").description("인터뷰 총 점수"),
+                                fieldWithPath("interview_view_count").description("인터뷰 조회 수"),
                                 fieldWithPath("interview_like_count").description("인터뷰 좋아요 수"),
                                 fieldWithPath("interview_already_liked").description("이미 인터뷰에 좋아요를 눌렀는지 여부"),
                                 fieldWithPath("interviewee_nickname").description("면접자 닉네임"),

--- a/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
+++ b/src/test/java/com/samhap/kokomen/interview/service/InterviewServiceTest.java
@@ -108,7 +108,7 @@ class InterviewServiceTest extends BaseTest {
     }
 
     @Test
-    void 인터뷰를_진행할_때_마지막_답변이면_현재_답변에_대한_피드백과__응답한다() {
+    void 인터뷰를_진행할_때_마지막_답변이면_현재_답변에_대한_피드백과_응답한다() {
         // given
         AnswerRank answerRank = AnswerRank.B;
         Member member = memberRepository.save(MemberFixtureBuilder.builder().build());
@@ -168,10 +168,10 @@ class InterviewServiceTest extends BaseTest {
         interviewRepository.save(interview);
 
         // when
-        interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
+        Long viewCount = interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("1.1.1.1"))
+                .interviewViewCount();
 
         // then
-        Long viewCount = Long.valueOf((String) redisTemplate.opsForValue().get(InterviewService.createInterviewViewCountKey(interview)));
         assertThat(viewCount).isEqualTo(1L);
     }
 
@@ -195,12 +195,12 @@ class InterviewServiceTest extends BaseTest {
         interviewRepository.save(interview);
 
         // when
-        interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
-        interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
-        interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
+        interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("1.1.1.1"));
+        interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("1.1.1.1"));
+        Long viewCount = interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("1.1.1.1"))
+                .interviewViewCount();
 
         // then
-        Long viewCount = Long.valueOf((String) redisTemplate.opsForValue().get(InterviewService.createInterviewViewCountKey(interview)));
         assertThat(viewCount).isEqualTo(1L);
     }
 
@@ -226,10 +226,10 @@ class InterviewServiceTest extends BaseTest {
         interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(otherMember.getId()), new ClientIp("123.123.123.123"));
 
         // when
-        interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(interviewee.getId()), new ClientIp("1.1.1.1"));
+        Long viewCount = interviewService.findOtherMemberInterviewResult(interview.getId(), new MemberAuth(interviewee.getId()), new ClientIp("1.1.1.1"))
+                .interviewViewCount();
 
         // then
-        Long viewCount = Long.valueOf((String) redisTemplate.opsForValue().get(InterviewService.createInterviewViewCountKey(interview)));
         assertThat(viewCount).isEqualTo(1L);
     }
 


### PR DESCRIPTION
# 작업 내용
- 다른 사람의 인터뷰 목록/결과 조회 API, 자신의 인터뷰 목록 조회 API 응답에 조회수 추가

# 스크린샷
현재 Flyway 관련 오류로 인해 로컬에서 Spring 애플리케이션이 정상적으로 실행되지 않고 있습니다.
해당 오류가 프로덕션 환경에서도 발생할 수 있는 원인인지 분석할 필요가 있어, MySQL 컨테이너의 볼륨은 삭제하지 않고 그대로 유지하기로 했습니다. 현재 기능 merge 되면 분석해 보려고 합니다.

이로 인해 API 문서의 스크린샷은 아직 첨부하지 못한 점 양해 부탁드립니다.