### PR TITLE
[Feat] - nginx.conf에서 Next.js 서버를 신뢰할 수 있는 프록시로 추가

### DIFF
--- a/docker/dev/nginx/nginx.conf
+++ b/docker/dev/nginx/nginx.conf
@@ -22,6 +22,9 @@ http {
         listen 443 ssl;
         server_name api-dev.kokomen.kr;
         server_tokens off;
+        set_real_ip_from 3.39.9.168;
+        real_ip_header X-Forwarded-For;
+        real_ip_recursive on;
 
         ssl_certificate /etc/letsencrypt/live/api-dev.kokomen.kr/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/api-dev.kokomen.kr/privkey.pem;

--- a/docker/prod/nginx/nginx.conf
+++ b/docker/prod/nginx/nginx.conf
@@ -7,6 +7,7 @@ http {
         listen 80;
 
         set_real_ip_from 10.0.0.0/16;
+        set_real_ip_from 43.203.50.14;
         real_ip_header X-Forwarded-For;
         real_ip_recursive on;
 


### PR DESCRIPTION
# 작업 내용
- SSR 환경에서 nginx가 X-Real-IP 헤더를 통해 실제 사용자 IP를 전달할 때, Next.js 서버의 IP 주소를 신뢰할 수 있는 프록시로 설정

# 참고 사항
merge 후 nginx.conf reload 해 주어야 합니다.