### PR TITLE
[Infra] - dev의 nginx와 notification 서버 연결

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -70,6 +70,16 @@ jobs:
           git sparse-checkout set docker
           git pull origin develop
 
+      - name: Create dev-kokomen-net Docker network
+        run: |
+          NETWORK_NAME="dev-kokomen-net"
+          if ! sudo docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+            echo "Creating Docker network: $NETWORK_NAME"
+            sudo docker network create --driver bridge "$NETWORK_NAME"
+          else
+            echo "Docker network '$NETWORK_NAME' already exists. Skipping."
+          fi
+
       - name: Docker run
         working-directory: /home/ubuntu
         env:

--- a/docker/dev/docker-compose-dev.yml
+++ b/docker/dev/docker-compose-dev.yml
@@ -174,10 +174,16 @@ services:
             scrape_interval: 15s
             static_configs:
               - targets: ['node:9100']
+        
           - job_name: 'mysql'
             scrape_interval: 15s
             static_configs:
               - targets: ['mysql-dev-exporter:9104']
+        
+          - job_name: 'notification-mysql'
+            scrape_interval: 15s
+            static_configs:
+              - targets: ['notification-mysql-dev-exporter:9104']
         EOF
         /bin/prometheus
     environment:

--- a/docker/dev/docker-compose-dev.yml
+++ b/docker/dev/docker-compose-dev.yml
@@ -19,6 +19,8 @@ services:
       OPEN_AI_API_KEY: ${OPEN_AI_API_KEY}
       KAKAO_CLIENT_ID_DEV: ${KAKAO_CLIENT_ID_DEV}
       KAKAO_CLIENT_SECRET_DEV: ${KAKAO_CLIENT_SECRET_DEV}
+    networks:
+      - dev-kokomen-net
 
   kokomen-mysql-dev:
     image: mysql:8.4.5
@@ -43,6 +45,8 @@ services:
       MYSQL_DATABASE: kokomen-dev
       LANG: C.UTF-8
       MYSQL_INIT_CONNECT: "SET NAMES utf8mb4"
+    networks:
+      - dev-kokomen-net
 
   mysql-dev-exporter:
     image: prom/mysqld-exporter
@@ -55,6 +59,8 @@ services:
       - "9104:9104"
     volumes:
       - ./my.cnf:/.my.cnf
+    networks:
+      - dev-kokomen-net
 
   kokomen-redis-dev:
     image: valkey/valkey:8.0.1
@@ -65,6 +71,8 @@ services:
       - kokomen-redis-data:/data
     environment:
       TZ: Asia/Seoul
+    networks:
+      - dev-kokomen-net
 
   nginx:
     image: nginx:1.28.0
@@ -80,6 +88,8 @@ services:
     restart: unless-stopped
     environment:
       TZ: Asia/Seoul
+    networks:
+      - dev-kokomen-net
 
   certbot:
     image: certbot/certbot
@@ -90,6 +100,8 @@ services:
     restart: unless-stopped
     environment:
       TZ: Asia/Seoul
+    networks:
+      - dev-kokomen-net
 
   loki:
     image: grafana/loki
@@ -102,6 +114,8 @@ services:
       - loki:/loki
     environment:
       TZ: Asia/Seoul
+    networks:
+      - dev-kokomen-net
 
   promtail:
     image: grafana/promtail
@@ -117,6 +131,8 @@ services:
     environment:
       TZ: Asia/Seoul
       HOSTNAME: ${HOSTNAME}
+    networks:
+      - dev-kokomen-net
 
   node:
     image: prom/node-exporter
@@ -131,6 +147,8 @@ services:
       - '/:/host:ro'
     environment:
       TZ: Asia/Seoul
+    networks:
+      - dev-kokomen-net
 
   prometheus:
     image: prom/prometheus
@@ -164,6 +182,8 @@ services:
         /bin/prometheus
     environment:
       TZ: Asia/Seoul
+    networks:
+      - dev-kokomen-net
 
   grafana:
     image: grafana/grafana
@@ -205,6 +225,8 @@ services:
           editable: false
         EOF
         /run.sh
+    networks:
+      - dev-kokomen-net
 
 volumes:
   promtail-tmp:
@@ -214,3 +236,8 @@ volumes:
   loki:
   prometheus:
   grafana:
+
+networks:
+  dev-kokomen-net:
+    external: true
+    driver: bridge

--- a/docker/dev/nginx/nginx.conf
+++ b/docker/dev/nginx/nginx.conf
@@ -8,9 +8,10 @@ http {
                     '"$http_user_agent" "$http_x_forwarded_for" '
                     '"$ssl_protocol/$ssl_cipher" "$content_length" "$request_length"';
     access_log /var/log/nginx/access.log main;
+
     server {
         listen 80;
-        server_name api-dev.kokomen.kr;
+        server_name api-dev.kokomen.kr notification.api.kokomen.kr;
         server_tokens off;
 
         location /.well-known/acme-challenge/ {
@@ -36,6 +37,27 @@ http {
 
         location / {
             set $backend "kokomen-dev-server:8080";
+            proxy_pass http://$backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-RequestID $request_id;
+            resolver 127.0.0.11 valid=5s;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name notification.api.kokomen.kr;
+        server_tokens off;
+        set_real_ip_from 3.39.9.168;
+        real_ip_header X-Forwarded-For;
+        real_ip_recursive on;
+
+        ssl_certificate /etc/letsencrypt/live/api-dev.kokomen.kr/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/api-dev.kokomen.kr/privkey.pem;
+
+        location / {
+            set $backend "kokomen-notification-dev-internal:8080";
             proxy_pass http://$backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/docker/dev/nginx/nginx.conf
+++ b/docker/dev/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
 
     server {
         listen 80;
-        server_name api-dev.kokomen.kr notification.api.kokomen.kr;
+        server_name api-dev.kokomen.kr notification-api-dev.kokomen.kr;
         server_tokens off;
 
         location /.well-known/acme-challenge/ {
@@ -47,17 +47,17 @@ http {
 
     server {
         listen 443 ssl;
-        server_name notification.api.kokomen.kr;
+        server_name notification-api-dev.kokomen.kr;
         server_tokens off;
         set_real_ip_from 3.39.9.168;
         real_ip_header X-Forwarded-For;
         real_ip_recursive on;
 
-        ssl_certificate /etc/letsencrypt/live/api-dev.kokomen.kr/fullchain.pem;
+        ssl_certificate /etc/letsencrypt/live/api-dev.kokomen.kr/fullchain.pem; # TODO: SSL 인증서 따로 필요
         ssl_certificate_key /etc/letsencrypt/live/api-dev.kokomen.kr/privkey.pem;
 
         location / {
-            set $backend "kokomen-notification-dev-internal:8080";
+            set $backend "kokomen-notification-dev-api:8080";
             proxy_pass http://$backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
# 작업 내용
- dev의 docker compose yml에서 모두가 같은 도커 네트워크에 포함되도록 설정
  - notification에서 띄우는 컨테이너와 같은 도커 네트워크에 포함시키기 위해
  - 그래야 nginx가 notification-api 컨테이너로 요청 포워딩할 수 있고,
  - kokomen-backend 컨테이너가 notification-internal 컨테이너로 요청을 쉽게 보낼 수 있다.
- dev의 nginx.conf에서 url 기반으로 요청을 포워딩할 수 있도록 수정
- 추가로 필요한 업무
  - [ ] merge 후 nginx docker container 재시작 필요
  - [ ] notification-api-dev.kokomen.kr이라는 서브도메인에 대한 SSL 인증서 어떻게 할 지 논의
  - [ ] 가비아에 notification-api-dev.kokomen.kr 서브도메인 등록

# 스크린샷

# 참고 사항
- notification 쪽 작업은 아직 진행중입니다.
